### PR TITLE
fix: keep looping while queue not empty

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -737,7 +737,7 @@ class AppendSession
 	 * Main processing loop that sends queued requests one at a time.
 	 */
 	private async processLoop(): Promise<void> {
-		while (!this.closed && this.queue.length > 0) {
+		while (this.queue.length > 0) {
 			this.inFlight = true;
 			const args = this.queue.shift()!;
 			const resolver = this.pendingResolvers.shift()!;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -457,8 +457,10 @@ class Batcher
 			start: (controller) => {
 				writableController = controller;
 			},
-			write: (chunk) =>
-				this.submit(Array.isArray(chunk) ? chunk : [chunk]).then((_) => {}),
+			write: (chunk) => {
+				const records = Array.isArray(chunk) ? chunk : [chunk];
+				this.submit(records);
+			},
 			close: () => {
 				this.closed = true;
 				this.flush();
@@ -651,11 +653,12 @@ class AppendSession
 			start: (controller) => {
 				writableController = controller;
 			},
-			write: (chunk) =>
+			write: (chunk) => {
 				this.submit(chunk.records, {
 					fencing_token: chunk.fencing_token,
 					match_seq_num: chunk.match_seq_num,
-				}).then((_) => {}),
+				});
+			},
 			close: async () => {
 				this.closed = true;
 				await this.waitForDrain();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -457,10 +457,8 @@ class Batcher
 			start: (controller) => {
 				writableController = controller;
 			},
-			write: (chunk) => {
-				const records = Array.isArray(chunk) ? chunk : [chunk];
-				this.submit(records);
-			},
+			write: (chunk) =>
+				this.submit(Array.isArray(chunk) ? chunk : [chunk]).then((_) => {}),
 			close: () => {
 				this.closed = true;
 				this.flush();
@@ -653,12 +651,11 @@ class AppendSession
 			start: (controller) => {
 				writableController = controller;
 			},
-			write: (chunk) => {
+			write: (chunk) =>
 				this.submit(chunk.records, {
 					fencing_token: chunk.fencing_token,
 					match_seq_num: chunk.match_seq_num,
-				});
-			},
+				}).then((_) => {}),
 			close: async () => {
 				this.closed = true;
 				await this.waitForDrain();


### PR DESCRIPTION
Main append session loop should continue so long as there are batches in the queue.

This was deadlocking:
```typescript
var sesh = await stream.appendSession();

function createStringStream(n: number, delayMs: number = 0): ReadableStream<string> {
	let count = 0;
	return new ReadableStream<string>({
		async pull(controller) {
			if (count < n) {
				if (delayMs > 0) {
					await new Promise(resolve=> setTimeout(resolve, delayMs));
				}
				controller.enqueue(`string ${count}`);
				count++;
			} else {
				controller.close();
			}
		}
	});
}

const toRecord = new TransformStream<string, AppendArgs>({
	transform(str, controller) {
		controller.enqueue({records: [AppendRecord.make(str)]});
	}
});

var pipe = await createStringStream(200, 1).pipeThrough(toRecord).pipeTo(sesh);
```

