### PR TITLE
meteredBytes logic for appends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .DS_Store
 
 .claude
+
+# local examples
+examples/local

--- a/examples/append.ts
+++ b/examples/append.ts
@@ -13,21 +13,21 @@ const streams = await basin.streams.list();
 if (streams.streams[0]) {
 	const stream = basin.stream(streams.streams[0].name);
 	// Create an append session
-	const session = await stream.appendSession("string");
+	const session = await stream.appendSession();
 
 	// You can submit directly to the session and get acknowledgement promises
-	const ack1 = await session.submit([AppendRecord.make.string("record 1")]);
-	const ack2 = await session.submit([AppendRecord.make.string("record 2")]);
+	const ack1 = await session.submit([AppendRecord.make("record 1")]);
+	const ack2 = await session.submit([AppendRecord.make("record 2")]);
 	console.log("Direct submits acknowledged:", ack1, ack2);
 
 	// Close the session (waits for all appends to complete)
 	await session.close();
 
 	// Example: Using BatchTransform with streaming pipeline
-	const session2 = await stream.appendSession("string");
+	const session2 = await stream.appendSession();
 
 	// Create a batcher that will batch records
-	const batcher = new BatchTransform<"string">({
+	const batcher = new BatchTransform({
 		lingerDuration: 20,
 		maxBatchRecords: 10,
 	});
@@ -47,9 +47,9 @@ if (streams.streams[0]) {
 
 	// Write records to the batcher
 	const writer = batcher.writable.getWriter();
-	await writer.write(AppendRecord.make.string("batched record 1"));
-	await writer.write(AppendRecord.make.string("batched record 2"));
-	await writer.write(AppendRecord.make.string("batched record 3"));
+	await writer.write(AppendRecord.make("batched record 1"));
+	await writer.write(AppendRecord.make("batched record 2"));
+	await writer.write(AppendRecord.make("batched record 3"));
 	await writer.close();
 
 	// Wait for pipeline to complete

--- a/examples/kitchen-sink.ts
+++ b/examples/kitchen-sink.ts
@@ -40,18 +40,17 @@ if (streams.streams[0]) {
 		bytesRead.records?.[0]?.headers,
 	);
 
-	stream.append(AppendRecord.make.bytes(new Uint8Array([1, 2])));
+	stream.append(AppendRecord.make(new Uint8Array([1, 2])));
 
 	// String format appends
 	const stringAppend = await stream.append([
-		AppendRecord.make.string("Hello, world!", {
+		AppendRecord.make("Hello, world!", {
 			foo: "bar",
 		}),
-		AppendRecord.fence.string("my-fence"),
-		AppendRecord.command.string("foo"),
+		AppendRecord.fence("my-fence"),
+		AppendRecord.command("foo"),
 		// still can just make by hand:
 		{
-			format: "string",
 			body: "hello, world!",
 			headers: [["foo", "bar"]],
 			timestamp: new Date().getTime(),
@@ -61,10 +60,13 @@ if (streams.streams[0]) {
 
 	// Bytes format appends
 	const bytesAppend = await stream.append([
-		AppendRecord.make.bytes(new Uint8Array([1, 2, 3]), [
+		AppendRecord.make(new Uint8Array([1, 2, 3]), [
 			[new TextEncoder().encode("foo"), new TextEncoder().encode("bar")],
 		]),
-		AppendRecord.fence.bytes("my-fence"),
+		AppendRecord.command(
+			new TextEncoder().encode("fence"),
+			new TextEncoder().encode("my-fence"),
+		),
 		AppendRecord.trim(0),
 	]);
 	console.log("bytes append", bytesAppend);

--- a/examples/kitchen-sink.ts
+++ b/examples/kitchen-sink.ts
@@ -40,29 +40,34 @@ if (streams.streams[0]) {
 		bytesRead.records?.[0]?.headers,
 	);
 
-	const append = await stream.append([
-		AppendRecord.make("Hello, world!", {
+	stream.append(AppendRecord.make.bytes(new Uint8Array([1, 2])));
+
+	// String format appends
+	const stringAppend = await stream.append([
+		AppendRecord.make.string("Hello, world!", {
 			foo: "bar",
 		}),
-		AppendRecord.make(new Uint8Array([1, 2, 3]), {
-			foo: "bar",
-		}),
-		AppendRecord.make(new Uint8Array([1, 2, 3]), [
-			[new TextEncoder().encode("foo"), new TextEncoder().encode("bar")],
-			[new TextEncoder().encode("baz"), "bak"],
-			["qux", new TextEncoder().encode("quux")],
-		]),
-		AppendRecord.fence("my-fence"),
-		AppendRecord.trim(0),
-		AppendRecord.command("foo"),
+		AppendRecord.fence.string("my-fence"),
+		AppendRecord.command.string("foo"),
 		// still can just make by hand:
 		{
+			format: "string",
 			body: "hello, world!",
 			headers: [["foo", "bar"]],
 			timestamp: new Date().getTime(),
 		},
 	]);
-	console.log("append", append);
+	console.log("string append", stringAppend);
+
+	// Bytes format appends
+	const bytesAppend = await stream.append([
+		AppendRecord.make.bytes(new Uint8Array([1, 2, 3]), [
+			[new TextEncoder().encode("foo"), new TextEncoder().encode("bar")],
+		]),
+		AppendRecord.fence.bytes("my-fence"),
+		AppendRecord.trim(0),
+	]);
+	console.log("bytes append", bytesAppend);
 	const readSession = await stream.readSession({
 		clamp: true,
 		tail_offset: 10,

--- a/src/batch-transform.ts
+++ b/src/batch-transform.ts
@@ -1,0 +1,207 @@
+import { S2Error } from "./error.js";
+import type {
+	AppendRecord as AppendRecordType,
+	BytesAppendRecord,
+	StringAppendRecord,
+} from "./stream.js";
+import { meteredSizeBytes } from "./utils.js";
+
+/** Helper type to get the correct AppendRecord type based on format */
+type RecordForFormat<F extends "string" | "bytes"> = F extends "string"
+	? StringAppendRecord
+	: BytesAppendRecord;
+
+export interface BatchTransformArgs {
+	/** Duration in milliseconds to wait before flushing a batch (default: 5ms) */
+	lingerDuration?: number;
+	/** Maximum number of records in a batch (default: 1000, max: 1000) */
+	maxBatchRecords?: number;
+	/** Maximum batch size in bytes (default: 1 MiB, max: 1 MiB) */
+	maxBatchBytes?: number;
+	/** Optional fencing token to enforce (remains static across batches) */
+	fencing_token?: string;
+	/** Optional sequence number to match for first batch (auto-increments for subsequent batches) */
+	match_seq_num?: number;
+}
+
+/** Batch output type with optional fencing token and match_seq_num */
+export type BatchOutput<F extends "string" | "bytes"> = {
+	records: RecordForFormat<F>[];
+	fencing_token?: string;
+	match_seq_num?: number;
+};
+
+/**
+ * A TransformStream that batches AppendRecords based on time, record count, and byte size.
+ *
+ * Input: AppendRecord (individual records)
+ * Output: { records: AppendRecord[], fencing_token?: string, match_seq_num?: number }
+ *
+ * @example
+ * ```typescript
+ * const batcher = new BatchTransform<"string">({
+ *   lingerDuration: 20,
+ *   maxBatchRecords: 100,
+ *   maxBatchBytes: 256 * 1024,
+ *   match_seq_num: 0  // Optional: auto-increments per batch
+ * });
+ *
+ * // Pipe through the batcher directly to a session
+ * readable.pipeThrough(batcher).pipeTo(session);
+ *
+ * // Or use manually
+ * const writer = batcher.writable.getWriter();
+ * writer.write(AppendRecord.make("foo"));
+ * await writer.close();
+ *
+ * for await (const batch of batcher.readable) {
+ *   console.log(`Got batch of ${batch.records.length} records`);
+ * }
+ * ```
+ */
+export class BatchTransform<
+	F extends "string" | "bytes",
+> extends TransformStream<RecordForFormat<F>, BatchOutput<F>> {
+	private currentBatch: RecordForFormat<F>[] = [];
+	private currentBatchSize: number = 0;
+	private lingerTimer: ReturnType<typeof setTimeout> | null = null;
+	private controller: TransformStreamDefaultController<BatchOutput<F>> | null =
+		null;
+	private readonly maxBatchRecords: number;
+	private readonly maxBatchBytes: number;
+	private readonly lingerDuration: number;
+	private readonly fencing_token?: string;
+	private next_match_seq_num?: number;
+	private expectedFormat?: "string" | "bytes";
+
+	constructor(args?: BatchTransformArgs) {
+		let controller: TransformStreamDefaultController<BatchOutput<F>>;
+
+		super({
+			start: (c) => {
+				controller = c;
+			},
+			transform: (chunk, c) => {
+				// Store controller reference on first transform
+				if (!this.controller) {
+					this.controller = c;
+				}
+				this.handleRecord(chunk);
+			},
+			flush: () => {
+				this.flush();
+			},
+		});
+
+		// Cap at maximum allowed values
+		this.maxBatchRecords = Math.min(args?.maxBatchRecords ?? 1000, 1000);
+		this.maxBatchBytes = Math.min(
+			args?.maxBatchBytes ?? 1024 * 1024,
+			1024 * 1024,
+		);
+		this.lingerDuration = args?.lingerDuration ?? 5;
+		this.fencing_token = args?.fencing_token;
+		this.next_match_seq_num = args?.match_seq_num;
+	}
+
+	private handleRecord(record: RecordForFormat<F>): void {
+		// Validate format consistency
+		if (!this.expectedFormat) {
+			this.expectedFormat = record.format;
+		} else if (record.format !== this.expectedFormat) {
+			throw new S2Error({
+				message: `Cannot batch ${record.format} records with ${this.expectedFormat} records. All records must have the same format.`,
+			});
+		}
+
+		const recordSize = meteredSizeBytes(record as AppendRecordType);
+
+		// Reject individual records that exceed the max batch size
+		if (recordSize > this.maxBatchBytes) {
+			throw new S2Error({
+				message: `Record size ${recordSize} bytes exceeds maximum batch size of ${this.maxBatchBytes} bytes`,
+			});
+		}
+
+		// Start linger timer on first record added to an empty batch
+		if (this.currentBatch.length === 0 && this.lingerDuration > 0) {
+			this.startLingerTimer();
+		}
+
+		// Check if adding this record would exceed limits
+		const wouldExceedRecords =
+			this.currentBatch.length + 1 > this.maxBatchRecords;
+		const wouldExceedBytes =
+			this.currentBatchSize + recordSize > this.maxBatchBytes;
+
+		if (wouldExceedRecords || wouldExceedBytes) {
+			this.flush();
+			// Restart linger timer for new batch
+			if (this.lingerDuration > 0) {
+				this.startLingerTimer();
+			}
+		}
+
+		// Add record to current batch
+		this.currentBatch.push(record);
+		this.currentBatchSize += recordSize;
+
+		// Check if we've now reached the limits
+		const nowExceedsRecords = this.currentBatch.length >= this.maxBatchRecords;
+		const nowExceedsBytes = this.currentBatchSize >= this.maxBatchBytes;
+
+		if (nowExceedsRecords || nowExceedsBytes) {
+			this.flush();
+		}
+	}
+
+	private flush(): void {
+		this.cancelLingerTimer();
+
+		if (this.currentBatch.length === 0) {
+			return;
+		}
+
+		// Auto-increment match_seq_num for next batch
+		const match_seq_num = this.next_match_seq_num;
+		if (this.next_match_seq_num !== undefined) {
+			this.next_match_seq_num += this.currentBatch.length;
+		}
+
+		// Emit the batch downstream with optional fencing token and match_seq_num
+		if (this.controller) {
+			const batch: BatchOutput<F> = {
+				records: [...this.currentBatch],
+			};
+			if (this.fencing_token !== undefined) {
+				batch.fencing_token = this.fencing_token;
+			}
+			if (match_seq_num !== undefined) {
+				batch.match_seq_num = match_seq_num;
+			}
+			this.controller.enqueue(batch);
+		}
+
+		// Reset batch
+		this.currentBatch = [];
+		this.currentBatchSize = 0;
+	}
+
+	private startLingerTimer(): void {
+		this.cancelLingerTimer();
+
+		this.lingerTimer = setTimeout(() => {
+			this.lingerTimer = null;
+			if (this.currentBatch.length > 0) {
+				this.flush();
+			}
+		}, this.lingerDuration);
+	}
+
+	private cancelLingerTimer(): void {
+		if (this.lingerTimer) {
+			clearTimeout(this.lingerTimer);
+			this.lingerTimer = null;
+		}
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export type {
 	ListBasinsArgs,
 	ReconfigureBasinArgs,
 } from "./basins.js";
+export type { BatchOutput, BatchTransformArgs } from "./batch-transform.js";
+export { BatchTransform } from "./batch-transform.js";
 export {
 	FencingTokenMismatchError,
 	RangeNotSatisfiableError,
@@ -69,4 +71,4 @@ export type {
 	ListStreamsArgs,
 	ReconfigureStreamArgs,
 } from "./streams.js";
-export { AppendRecord } from "./utils.js";
+export { AppendRecord, meteredSizeBytes, utf8ByteLength } from "./utils.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,8 @@ export type {
 	AppendArgs,
 	ReadArgs,
 	ReadBatch,
+	ReadRecord as SequencedRecord,
 	ReadSession,
-	SequencedRecord,
 } from "./stream.js";
 export type {
 	CreateStreamArgs,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -338,7 +338,7 @@ export type BytesAppendArgs = Omit<GeneratedAppendInput, "records"> & {
 
 export type AppendArgs = StringAppendArgs | BytesAppendArgs;
 
-class ReadSession<
+export class ReadSession<
 	Format extends "string" | "bytes" = "string",
 > extends EventStream<SequencedRecord<Format>> {
 	static async create<Format extends "string" | "bytes" = "string">(

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -326,7 +326,6 @@ export type BytesAppendRecord = Omit<
 	headers?: Array<[Uint8Array, Uint8Array]>;
 };
 
-
 export type AppendRecord = StringAppendRecord | BytesAppendRecord;
 
 export type StringAppendArgs = Omit<GeneratedAppendInput, "records"> & {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -331,6 +331,9 @@ export type AppendRecord =
 	| AppendRecordForFormat<"string">
 	| AppendRecordForFormat<"bytes">;
 
+export type StringAppendRecord = AppendRecordForFormat<"string">;
+export type BytesAppendRecord = AppendRecordForFormat<"bytes">;
+
 export type AppendArgs = Omit<GeneratedAppendInput, "records"> & {
 	records: Array<AppendRecord>;
 };

--- a/src/tests/appendSession.test.ts
+++ b/src/tests/appendSession.test.ts
@@ -43,10 +43,10 @@ describe("AppendSession", () => {
 		// default fallback
 		appendSpy.mockResolvedValue(makeAck(999));
 
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 
-		const p1 = session.submit([{ body: "a" }]);
-		const p2 = session.submit([{ body: "b" }]);
+		const p1 = session.submit([{ format: "string", body: "a" }]);
+		const p2 = session.submit([{ format: "string", body: "b" }]);
 
 		const ack1 = await p1;
 		const ack2 = await p2;
@@ -63,7 +63,7 @@ describe("AppendSession", () => {
 			.mockResolvedValueOnce(makeAck(1))
 			.mockResolvedValueOnce(makeAck(2));
 
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 		const acks = session.acks();
 
 		const received: AppendAck[] = [];
@@ -73,8 +73,8 @@ describe("AppendSession", () => {
 			}
 		})();
 
-		await session.submit([{ body: "a" }]);
-		await session.submit([{ body: "b" }]);
+		await session.submit([{ format: "string", body: "a" }]);
+		await session.submit([{ format: "string", body: "b" }]);
 
 		await session.close();
 		await consumer;
@@ -90,10 +90,10 @@ describe("AppendSession", () => {
 		appendSpy.mockResolvedValueOnce(makeAck(1));
 		appendSpy.mockResolvedValueOnce(makeAck(2));
 
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 
-		const p1 = session.submit([{ body: "x" }]);
-		const p2 = session.submit([{ body: "y" }]);
+		const p1 = session.submit([{ format: "string", body: "x" }]);
+		const p2 = session.submit([{ format: "string", body: "y" }]);
 
 		await Promise.all([p1, p2]);
 		await session.close();
@@ -106,11 +106,13 @@ describe("AppendSession", () => {
 	it("submit after close() rejects", async () => {
 		const stream = makeStream();
 		vi.spyOn(stream, "append").mockResolvedValue(makeAck(1));
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 
 		await session.close();
 
-		await expect(session.submit([{ body: "x" }])).rejects.toMatchObject({
+		await expect(
+			session.submit([{ format: "string", body: "x" }]),
+		).rejects.toMatchObject({
 			message: expect.stringContaining("AppendSession is closed"),
 		});
 	});
@@ -121,10 +123,10 @@ describe("AppendSession", () => {
 
 		appendSpy.mockRejectedValueOnce(new Error("boom"));
 
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 
-		const p1 = session.submit([{ body: "a" }]);
-		const p2 = session.submit([{ body: "b" }]);
+		const p1 = session.submit([{ format: "string", body: "a" }]);
+		const p2 = session.submit([{ format: "string", body: "b" }]);
 		// suppress unhandled rejection warnings
 		p1.catch(() => {});
 		p2.catch(() => {});
@@ -134,7 +136,7 @@ describe("AppendSession", () => {
 
 		// After error, queue should be empty; new submit should restart processing
 		appendSpy.mockResolvedValueOnce(makeAck(3));
-		const p3 = session.submit([{ body: "c" }]);
+		const p3 = session.submit([{ format: "string", body: "c" }]);
 		await expect(p3).resolves.toBeTruthy();
 		expect(appendSpy).toHaveBeenCalledTimes(2); // 1 throw + 1 success
 	});
@@ -142,8 +144,69 @@ describe("AppendSession", () => {
 	it("updates lastSeenPosition after successful append", async () => {
 		const stream = makeStream();
 		vi.spyOn(stream, "append").mockResolvedValue(makeAck(42));
-		const session = await stream.appendSession();
-		await session.submit([{ body: "z" }]);
+		const session = await stream.appendSession("string");
+		await session.submit([{ format: "string", body: "z" }]);
 		expect(session.lastSeenPosition?.end.seq_num).toBe(42);
+	});
+
+	it("applies backpressure when queue exceeds maxQueuedBytes", async () => {
+		const stream = makeStream();
+		const appendSpy = vi.spyOn(stream, "append");
+
+		// Create a session with very small max queued bytes (100 bytes)
+		const session = await stream.appendSession("string", {
+			maxQueuedBytes: 100,
+		});
+
+		// Control when appends resolve
+		let resolveFirst: any;
+		const firstPromise = new Promise<AppendAck>((resolve) => {
+			resolveFirst = () => resolve(makeAck(1));
+		});
+
+		appendSpy.mockReturnValueOnce(firstPromise);
+		appendSpy.mockResolvedValueOnce(makeAck(2));
+		appendSpy.mockResolvedValueOnce(makeAck(3));
+
+		// Use the WritableStream interface (session IS a WritableStream)
+		const writer = session.getWriter();
+
+		// Submit first batch (50 bytes) - should succeed immediately
+		const largeBody = "x".repeat(42); // ~50 bytes with overhead
+		const p1 = writer.write({
+			records: [{ format: "string", body: largeBody }],
+		});
+
+		// Submit second batch (50 bytes) - should also queue
+		const p2 = writer.write({
+			records: [{ format: "string", body: largeBody }],
+		});
+
+		// Submit third batch (50 bytes) - should block due to backpressure
+		let thirdWriteStarted = false;
+		const p3 = (async () => {
+			await writer.write({ records: [{ format: "string", body: largeBody }] });
+			thirdWriteStarted = true;
+		})();
+
+		// Give time for any immediate processing
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Third write should be blocked waiting for capacity
+		expect(thirdWriteStarted).toBe(false);
+
+		// Resolve first append to free capacity
+		resolveFirst();
+		await p1;
+
+		// Now third should be able to proceed
+		await p2;
+		await p3;
+
+		expect(thirdWriteStarted).toBe(true);
+		expect(appendSpy).toHaveBeenCalledTimes(3);
+
+		await writer.close();
 	});
 });

--- a/src/tests/batch-transform.test.ts
+++ b/src/tests/batch-transform.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, it } from "vitest";
+import { BatchTransform } from "../batch-transform.js";
+import { S2Error } from "../error.js";
+
+describe("BatchTransform", () => {
+	it("batches records based on linger duration", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 50,
+			maxBatchRecords: 100,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write 3 records quickly
+		writer.write({ format: "string", body: "a" });
+		writer.write({ format: "string", body: "b" });
+		writer.write({ format: "string", body: "c" });
+
+		// Wait for linger duration
+		await new Promise((resolve) => setTimeout(resolve, 60));
+
+		// Should get one batch with all 3 records
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(3);
+		expect(result.value?.records[0]?.body).toBe("a");
+		expect(result.value?.records[1]?.body).toBe("b");
+		expect(result.value?.records[2]?.body).toBe("c");
+
+		await writer.close();
+		reader.releaseLock();
+	});
+
+	it("flushes immediately when max records reached", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 1000, // Long linger, should flush before this
+			maxBatchRecords: 2,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write 2 records - should flush immediately
+		writer.write({ format: "string", body: "a" });
+		writer.write({ format: "string", body: "b" });
+
+		// Should get batch immediately (no need to wait for linger)
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+
+		// Write 2 more - should flush again
+		writer.write({ format: "string", body: "c" });
+		writer.write({ format: "string", body: "d" });
+
+		const result2 = await reader.read();
+		expect(result2.done).toBe(false);
+		expect(result2.value?.records).toHaveLength(2);
+
+		await writer.close();
+		reader.releaseLock();
+	});
+
+	it("flushes when max bytes reached", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 1000,
+			maxBatchBytes: 30, // Small batch size
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write and read concurrently
+		const writePromise = (async () => {
+			// Each record is ~13 bytes (8 overhead + 5 body)
+			// Two records = ~26 bytes, adding third would exceed 30
+			await writer.write({ format: "string", body: "hello" }); // ~13 bytes
+			await writer.write({ format: "string", body: "world" }); // ~13 bytes
+			await writer.write({ format: "string", body: "test!" }); // ~13 bytes
+			await writer.close();
+		})();
+
+		// Should get first batch with 2 records
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+
+		// Third record starts new batch
+		const result2 = await reader.read();
+		expect(result2.done).toBe(false);
+		expect(result2.value?.records).toHaveLength(1);
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("flushes remaining records on close", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10000, // Very long linger
+			maxBatchRecords: 100,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write and close in parallel with reading
+		const writePromise = (async () => {
+			await writer.write({ format: "string", body: "a" });
+			await writer.write({ format: "string", body: "b" });
+			await writer.close();
+		})();
+
+		// Should get batch after close
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+
+		// Stream should be done
+		const result2 = await reader.read();
+		expect(result2.done).toBe(true);
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("works with bytes format", async () => {
+		const batcher = new BatchTransform<"bytes">({
+			lingerDuration: 50,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		writer.write({ format: "bytes", body: new Uint8Array([1, 2, 3]) });
+		writer.write({ format: "bytes", body: new Uint8Array([4, 5, 6]) });
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+
+		await writer.close();
+		reader.releaseLock();
+	});
+
+	it("can be used with pipeTo", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+		});
+
+		// Create a readable stream of records
+		const records = [
+			{ format: "string", body: "a" },
+			{ format: "string", body: "b" },
+			{ format: "string", body: "c" },
+		];
+
+		const sourceStream = new ReadableStream({
+			async start(controller) {
+				for (const record of records) {
+					controller.enqueue(record);
+				}
+				controller.close();
+			},
+		});
+
+		// Collect batches
+		const batches: Array<{ records: typeof records }> = [];
+		const collectStream = new WritableStream({
+			write(batch) {
+				batches.push(batch);
+			},
+		});
+
+		// Pipe through batcher
+		await sourceStream.pipeThrough(batcher).pipeTo(collectStream);
+
+		// Should have collected batches
+		expect(batches.length).toBeGreaterThan(0);
+		const totalRecords = batches.flatMap((b) => b.records).length;
+		expect(totalRecords).toBe(3);
+	});
+
+	it("handles rapid writes with linger", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 20,
+			maxBatchRecords: 10,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write 5 records rapidly
+		for (let i = 0; i < 5; i++) {
+			writer.write({ format: "string", body: `record-${i}` });
+		}
+
+		// Wait for linger
+		await new Promise((resolve) => setTimeout(resolve, 30));
+
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(5);
+
+		await writer.close();
+		reader.releaseLock();
+	});
+
+	it("respects maximum limits (capped at 1000 records, 1 MiB)", () => {
+		// Should cap maxBatchRecords at 1000
+		const batcher1 = new BatchTransform<"string">({
+			maxBatchRecords: 5000, // Will be capped to 1000
+		});
+		// We can't directly access private fields, but we can verify behavior
+
+		// Should cap maxBatchBytes at 1 MiB
+		const batcher2 = new BatchTransform<"string">({
+			maxBatchBytes: 10 * 1024 * 1024, // Will be capped to 1 MiB
+		});
+
+		// Both should construct without error
+		expect(batcher1).toBeDefined();
+		expect(batcher2).toBeDefined();
+	});
+
+	it("handles empty batches gracefully", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Close without writing anything
+		await writer.close();
+
+		// Should get done immediately with no batches
+		const result = await reader.read();
+		expect(result.done).toBe(true);
+
+		reader.releaseLock();
+	});
+
+	it("cancels linger timer when batch is flushed early", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 1000, // Long linger
+			maxBatchRecords: 2,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write and read concurrently
+		const writePromise = (async () => {
+			// Write 2 records - should flush immediately due to maxBatchRecords
+			await writer.write({ format: "string", body: "a" });
+			await writer.write({ format: "string", body: "b" });
+			// Write one more and immediately close
+			await writer.write({ format: "string", body: "c" });
+			await writer.close();
+		})();
+
+		// Should get first batch immediately (linger timer should be cancelled)
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+
+		// Should get remaining batch without waiting for linger
+		const result2 = await reader.read();
+		expect(result2.done).toBe(false);
+		expect(result2.value?.records).toHaveLength(1);
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("works in a for-await loop", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+		});
+
+		const writer = batcher.writable.getWriter();
+
+		// Write and close in parallel with reading
+		const writePromise = (async () => {
+			await writer.write({ format: "string", body: "a" });
+			await writer.write({ format: "string", body: "b" });
+			await writer.write({ format: "string", body: "c" });
+			await writer.close();
+		})();
+
+		// Consume with for-await
+		const batches: Array<Array<{ body?: string; format: string }>> = [];
+		for await (const batch of batcher.readable as unknown as AsyncIterable<{
+			records: Array<{ body?: string; format: string }>;
+		}>) {
+			batches.push(batch.records);
+		}
+
+		await writePromise;
+
+		expect(batches.length).toBeGreaterThan(0);
+		const totalRecords = batches.flat().length;
+		expect(totalRecords).toBe(3);
+	});
+
+	it("rejects individual records that exceed max batch bytes", async () => {
+		const batcher = new BatchTransform<"string">({
+			maxBatchBytes: 30, // Small limit
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Create a record that's too large (body alone is 100 bytes, plus 8 byte overhead = 108 bytes)
+		const largeBody = "x".repeat(100);
+
+		// Write and read concurrently to avoid deadlock
+		const writePromise = writer
+			.write({ format: "string", body: largeBody })
+			.catch((err) => err);
+		const readPromise = reader.read().catch((err) => err);
+
+		// Either the write or read should fail with the error
+		const [writeResult, readResult] = await Promise.all([
+			writePromise,
+			readPromise,
+		]);
+
+		// At least one should be an error
+		const error = writeResult instanceof S2Error ? writeResult : readResult;
+		expect(error).toBeInstanceOf(S2Error);
+		expect(error.message).toContain("exceeds maximum batch size");
+	});
+
+	it("rejects oversized bytes records", async () => {
+		const batcher = new BatchTransform<"bytes">({
+			maxBatchBytes: 20,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Create a bytes record that's too large
+		const largeBody = new Uint8Array(50); // 50 bytes + 8 overhead = 58 bytes
+
+		// Write and read concurrently to avoid deadlock
+		const writePromise = writer
+			.write({ format: "bytes", body: largeBody })
+			.catch((err) => err);
+		const readPromise = reader.read().catch((err) => err);
+
+		// Either the write or read should fail with the error
+		const [writeResult, readResult] = await Promise.all([
+			writePromise,
+			readPromise,
+		]);
+
+		// At least one should be an error
+		const error = writeResult instanceof S2Error ? writeResult : readResult;
+		expect(error).toBeInstanceOf(S2Error);
+		expect(error.message).toContain("exceeds maximum batch size");
+	});
+
+	it("includes fencing_token in batch output", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+			fencing_token: "my-fence-token",
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		const writePromise = (async () => {
+			await writer.write({ format: "string", body: "a" });
+			await writer.write({ format: "string", body: "b" });
+			await writer.close();
+		})();
+
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(2);
+		expect(result.value?.fencing_token).toBe("my-fence-token");
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("auto-increments match_seq_num across batches", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+			maxBatchRecords: 2,
+			match_seq_num: 0, // Start at 0
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		const writePromise = (async () => {
+			// First batch: 2 records
+			await writer.write({ format: "string", body: "a" });
+			await writer.write({ format: "string", body: "b" });
+			// Second batch: 3 records
+			await writer.write({ format: "string", body: "c" });
+			await writer.write({ format: "string", body: "d" });
+			await writer.write({ format: "string", body: "e" });
+			await writer.close();
+		})();
+
+		// First batch should have match_seq_num: 0 (2 records)
+		const result1 = await reader.read();
+		expect(result1.done).toBe(false);
+		expect(result1.value?.records).toHaveLength(2);
+		expect(result1.value?.match_seq_num).toBe(0);
+
+		// Second batch should have match_seq_num: 2 (incremented by batch size)
+		const result2 = await reader.read();
+		expect(result2.done).toBe(false);
+		expect(result2.value?.records).toHaveLength(2);
+		expect(result2.value?.match_seq_num).toBe(2);
+
+		// Third batch should have match_seq_num: 4
+		const result3 = await reader.read();
+		expect(result3.done).toBe(false);
+		expect(result3.value?.records).toHaveLength(1);
+		expect(result3.value?.match_seq_num).toBe(4);
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("works without fencing_token or match_seq_num", async () => {
+		const batcher = new BatchTransform<"string">({
+			lingerDuration: 10,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		const writePromise = (async () => {
+			await writer.write({ format: "string", body: "a" });
+			await writer.close();
+		})();
+
+		const result = await reader.read();
+		expect(result.done).toBe(false);
+		expect(result.value?.records).toHaveLength(1);
+		expect(result.value?.fencing_token).toBeUndefined();
+		expect(result.value?.match_seq_num).toBeUndefined();
+
+		await writePromise;
+		reader.releaseLock();
+	});
+
+	it("rejects mixed format records", async () => {
+		const batcher = new BatchTransform<"string" | "bytes">({
+			lingerDuration: 10,
+		});
+
+		const writer = batcher.writable.getWriter();
+		const reader = batcher.readable.getReader();
+
+		// Write and read concurrently to avoid deadlock
+		const writePromise = (async () => {
+			await writer.write({ format: "string", body: "a" });
+			// Try to write a bytes record - should fail
+			await writer.write({ format: "bytes", body: new Uint8Array([1, 2, 3]) });
+		})().catch((err) => err);
+
+		const readPromise = reader.read().catch((err) => err);
+
+		// Either the write or read should fail with the error
+		const [writeResult, readResult] = await Promise.all([
+			writePromise,
+			readPromise,
+		]);
+
+		// At least one should be an error
+		const error = writeResult instanceof S2Error ? writeResult : readResult;
+		expect(error).toBeInstanceOf(S2Error);
+		expect(error.message).toContain("Cannot batch bytes records with string");
+	});
+});

--- a/src/tests/batch-transform.test.ts
+++ b/src/tests/batch-transform.test.ts
@@ -4,7 +4,7 @@ import { S2Error } from "../error.js";
 
 describe("BatchTransform", () => {
 	it("batches records based on linger duration", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 50,
 			maxBatchRecords: 100,
 		});
@@ -33,7 +33,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("flushes immediately when max records reached", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000, // Long linger, should flush before this
 			maxBatchRecords: 2,
 		});
@@ -63,7 +63,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("flushes when max bytes reached", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000,
 			maxBatchBytes: 30, // Small batch size
 		});
@@ -96,7 +96,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("flushes remaining records on close", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10000, // Very long linger
 			maxBatchRecords: 100,
 		});
@@ -125,7 +125,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("works with bytes format", async () => {
-		const batcher = new BatchTransform<"bytes">({
+		const batcher = new BatchTransform({
 			lingerDuration: 50,
 		});
 
@@ -146,7 +146,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("can be used with pipeTo", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 		});
 
@@ -180,7 +180,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("handles rapid writes with linger", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 20,
 			maxBatchRecords: 10,
 		});
@@ -206,13 +206,13 @@ describe("BatchTransform", () => {
 
 	it("respects maximum limits (capped at 1000 records, 1 MiB)", () => {
 		// Should cap maxBatchRecords at 1000
-		const batcher1 = new BatchTransform<"string">({
+		const batcher1 = new BatchTransform({
 			maxBatchRecords: 5000, // Will be capped to 1000
 		});
 		// We can't directly access private fields, but we can verify behavior
 
 		// Should cap maxBatchBytes at 1 MiB
-		const batcher2 = new BatchTransform<"string">({
+		const batcher2 = new BatchTransform({
 			maxBatchBytes: 10 * 1024 * 1024, // Will be capped to 1 MiB
 		});
 
@@ -222,7 +222,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("handles empty batches gracefully", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 		});
 
@@ -240,7 +240,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("cancels linger timer when batch is flushed early", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000, // Long linger
 			maxBatchRecords: 2,
 		});
@@ -273,7 +273,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("works in a for-await loop", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 		});
 
@@ -303,7 +303,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("rejects individual records that exceed max batch bytes", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			maxBatchBytes: 30, // Small limit
 		});
 
@@ -330,7 +330,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("rejects oversized bytes records", async () => {
-		const batcher = new BatchTransform<"bytes">({
+		const batcher = new BatchTransform({
 			maxBatchBytes: 20,
 		});
 
@@ -357,7 +357,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("includes fencing_token in batch output", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 			fencing_token: "my-fence-token",
 		});
@@ -381,7 +381,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("auto-increments match_seq_num across batches", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 			maxBatchRecords: 2,
 			match_seq_num: 0, // Start at 0
@@ -424,7 +424,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("works without fencing_token or match_seq_num", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 		});
 

--- a/src/tests/batcher-session.integration.test.ts
+++ b/src/tests/batcher-session.integration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BatchTransform } from "../batch-transform.js";
 import type { AppendAck } from "../generated/index.js";
 import { S2Stream } from "../stream.js";
 
@@ -10,7 +11,7 @@ const makeAck = (n: number): AppendAck => ({
 	tail: { seq_num: n, timestamp: 0 },
 });
 
-describe("Batcher + AppendSession integration", () => {
+describe("BatchTransform + AppendSession integration", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});
@@ -22,18 +23,25 @@ describe("Batcher + AppendSession integration", () => {
 
 	it("linger-driven batching yields single session submission", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 		const appendSpy = vi.spyOn(stream, "append").mockResolvedValue(makeAck(1));
-		const batcher = session.makeBatcher({
+
+		const batcher = new BatchTransform<"string">({
 			lingerDuration: 10,
-			maxBatchSize: 100,
+			maxBatchRecords: 100,
 		});
 
-		const p1 = batcher.submit({ body: "a" });
-		const p2 = batcher.submit({ body: "b" });
+		// Pipe batcher output to session
+		const pipePromise = batcher.readable.pipeTo(session);
 
+		const writer = batcher.writable.getWriter();
+		await writer.write({ format: "string", body: "a" });
+		await writer.write({ format: "string", body: "b" });
+		await writer.close();
+
+		// Wait for linger to flush and pipe to complete
 		await vi.advanceTimersByTimeAsync(12);
-		await Promise.all([p1, p2]);
+		await pipePromise;
 
 		expect(appendSpy).toHaveBeenCalledTimes(1);
 		expect(appendSpy.mock.calls?.[0]?.[0]).toHaveLength(2);
@@ -41,40 +49,64 @@ describe("Batcher + AppendSession integration", () => {
 
 	it("batch overflow increments match_seq_num across multiple flushes", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 		const appendSpy = vi.spyOn(stream, "append");
 		appendSpy.mockResolvedValueOnce(makeAck(1));
 		appendSpy.mockResolvedValueOnce(makeAck(2));
-		const batcher = session.makeBatcher({
+
+		const batcher = new BatchTransform<"string">({
 			lingerDuration: 0,
-			maxBatchSize: 2,
+			maxBatchRecords: 2,
 			match_seq_num: 5,
 		});
 
-		const p1 = batcher.submit([{ body: "1" }, { body: "2" }]);
-		batcher.flush();
-		await p1;
-		const p2 = batcher.submit([{ body: "3" }]);
-		batcher.flush();
-		await p2;
+		// Pipe batcher output to session
+		const pipePromise = batcher.readable.pipeTo(session);
+
+		const writer = batcher.writable.getWriter();
+		await writer.write({ format: "string", body: "1" });
+		await writer.write({ format: "string", body: "2" });
+		await writer.write({ format: "string", body: "3" });
+		await writer.close();
+
+		await pipePromise;
 
 		expect(appendSpy).toHaveBeenCalledTimes(2);
 		expect(appendSpy.mock.calls?.[0]?.[1]).toMatchObject({ match_seq_num: 5 });
 		expect(appendSpy.mock.calls?.[1]?.[1]).toMatchObject({ match_seq_num: 7 });
 	});
 
-	it("batcher promise resolves with ack from session/stream", async () => {
+	it("batches are acknowledged via session.acks()", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession();
+		const session = await stream.appendSession("string");
 		vi.spyOn(stream, "append").mockResolvedValue(makeAck(123));
-		const batcher = session.makeBatcher({
+
+		const batcher = new BatchTransform<"string">({
 			lingerDuration: 0,
-			maxBatchSize: 10,
+			maxBatchRecords: 10,
 		});
 
-		const ackPromise = batcher.submit({ body: "x" });
-		batcher.flush();
-		const ack = await ackPromise;
-		expect(ack.end.seq_num).toBe(123);
+		// Collect acks
+		const acks: AppendAck[] = [];
+		const acksPromise = (async () => {
+			for await (const ack of session.acks()) {
+				acks.push(ack);
+			}
+		})();
+
+		// Pipe batcher output to session (this will close the session when done)
+		const pipePromise = batcher.readable.pipeTo(session);
+
+		const writer = batcher.writable.getWriter();
+		await writer.write({ format: "string", body: "x" });
+		await writer.close();
+
+		// Wait for pipe to complete (which closes the session)
+		await pipePromise;
+		// Wait for acks to finish
+		await acksPromise;
+
+		expect(acks).toHaveLength(1);
+		expect(acks[0]?.end.seq_num).toBe(123);
 	});
 });

--- a/src/tests/batcher-session.integration.test.ts
+++ b/src/tests/batcher-session.integration.test.ts
@@ -23,7 +23,7 @@ describe("BatchTransform + AppendSession integration", () => {
 
 	it("linger-driven batching yields single session submission", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession("string");
+		const session = await stream.appendSession();
 		const appendSpy = vi.spyOn(stream, "append").mockResolvedValue(makeAck(1));
 
 		const batcher = new BatchTransform<"string">({
@@ -35,8 +35,8 @@ describe("BatchTransform + AppendSession integration", () => {
 		const pipePromise = batcher.readable.pipeTo(session);
 
 		const writer = batcher.writable.getWriter();
-		await writer.write({ format: "string", body: "a" });
-		await writer.write({ format: "string", body: "b" });
+		await writer.write({ body: "a" });
+		await writer.write({ body: "b" });
 		await writer.close();
 
 		// Wait for linger to flush and pipe to complete
@@ -49,7 +49,7 @@ describe("BatchTransform + AppendSession integration", () => {
 
 	it("batch overflow increments match_seq_num across multiple flushes", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession("string");
+		const session = await stream.appendSession();
 		const appendSpy = vi.spyOn(stream, "append");
 		appendSpy.mockResolvedValueOnce(makeAck(1));
 		appendSpy.mockResolvedValueOnce(makeAck(2));
@@ -64,9 +64,9 @@ describe("BatchTransform + AppendSession integration", () => {
 		const pipePromise = batcher.readable.pipeTo(session);
 
 		const writer = batcher.writable.getWriter();
-		await writer.write({ format: "string", body: "1" });
-		await writer.write({ format: "string", body: "2" });
-		await writer.write({ format: "string", body: "3" });
+		await writer.write({ body: "1" });
+		await writer.write({ body: "2" });
+		await writer.write({ body: "3" });
 		await writer.close();
 
 		await pipePromise;
@@ -78,7 +78,7 @@ describe("BatchTransform + AppendSession integration", () => {
 
 	it("batches are acknowledged via session.acks()", async () => {
 		const stream = makeStream();
-		const session = await stream.appendSession("string");
+		const session = await stream.appendSession();
 		vi.spyOn(stream, "append").mockResolvedValue(makeAck(123));
 
 		const batcher = new BatchTransform<"string">({
@@ -98,7 +98,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		const pipePromise = batcher.readable.pipeTo(session);
 
 		const writer = batcher.writable.getWriter();
-		await writer.write({ format: "string", body: "x" });
+		await writer.write({ body: "x" });
 		await writer.close();
 
 		// Wait for pipe to complete (which closes the session)

--- a/src/tests/batcher-session.integration.test.ts
+++ b/src/tests/batcher-session.integration.test.ts
@@ -26,7 +26,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		const session = await stream.appendSession();
 		const appendSpy = vi.spyOn(stream, "append").mockResolvedValue(makeAck(1));
 
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 10,
 			maxBatchRecords: 100,
 		});
@@ -54,7 +54,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		appendSpy.mockResolvedValueOnce(makeAck(1));
 		appendSpy.mockResolvedValueOnce(makeAck(2));
 
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 0,
 			maxBatchRecords: 2,
 			match_seq_num: 5,
@@ -81,7 +81,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		const session = await stream.appendSession();
 		vi.spyOn(stream, "append").mockResolvedValue(makeAck(123));
 
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 0,
 			maxBatchRecords: 10,
 		});

--- a/src/tests/batcher.test.ts
+++ b/src/tests/batcher.test.ts
@@ -4,7 +4,7 @@ import { S2Error } from "../error.js";
 
 describe("BatchTransform", () => {
 	it("close() flushes remaining records", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000,
 			maxBatchRecords: 10,
 		});
@@ -26,7 +26,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("propagates fencing_token and auto-increments match_seq_num across batches", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 0,
 			maxBatchRecords: 2,
 			fencing_token: "ft",
@@ -64,7 +64,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("flushes immediately when max records reached", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000, // Long linger
 			maxBatchRecords: 2,
 		});
@@ -94,7 +94,7 @@ describe("BatchTransform", () => {
 	});
 
 	it("flushes when max bytes reached", async () => {
-		const batcher = new BatchTransform<"string">({
+		const batcher = new BatchTransform({
 			lingerDuration: 1000,
 			maxBatchBytes: 30, // Small batch size
 		});

--- a/src/tests/meteredSize.test.ts
+++ b/src/tests/meteredSize.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { AppendRecord, meteredSizeBytes } from "../utils.js";
+
+describe("meteredSizeBytes", () => {
+	it("calculates size for string format records", () => {
+		const record = AppendRecord.make.string("hello", {
+			foo: "bar",
+			baz: "qux",
+		});
+
+		const size = meteredSizeBytes(record);
+
+		// body: "hello" = 5 bytes
+		// headers: "foo" = 3, "bar" = 3, "baz" = 3, "qux" = 3 = 12 bytes
+		// overhead: 8 + 2*2 (2 headers) = 12 bytes
+		// Total: 8 + 4 + 12 + 5 = 29 bytes
+		expect(size).toBe(29);
+	});
+
+	it("calculates size for string format with UTF-8 characters", () => {
+		const record = AppendRecord.make.string("hello 世界", {
+			emoji: "🚀",
+		});
+
+		const size = meteredSizeBytes(record);
+
+		// body: "hello 世界" = 12 bytes (hello + space = 6, 世 = 3, 界 = 3)
+		// headers: "emoji" = 5, "🚀" = 4 = 9 bytes
+		// overhead: 8 + 2*1 (1 header) = 10 bytes
+		// Total: 8 + 2 + 9 + 12 = 31 bytes
+		expect(size).toBe(31);
+	});
+
+	it("calculates size for bytes format records", () => {
+		const record = AppendRecord.make.bytes(new Uint8Array([1, 2, 3, 4, 5]), [
+			[new Uint8Array([10, 20]), new Uint8Array([30, 40, 50])],
+		]);
+
+		const size = meteredSizeBytes(record);
+
+		// body: 5 bytes
+		// headers: key 2 bytes, value 3 bytes = 5 bytes
+		// overhead: 8 + 2*1 (1 header) = 10 bytes
+		// Total: 8 + 2 + 5 + 5 = 20 bytes
+		expect(size).toBe(20);
+	});
+
+	it("calculates size for record with no body", () => {
+		const record = AppendRecord.make.string(undefined, {
+			foo: "bar",
+		});
+
+		const size = meteredSizeBytes(record);
+
+		// body: 0 bytes
+		// headers: "foo" = 3, "bar" = 3 = 6 bytes
+		// overhead: 8 + 2*1 (1 header) = 10 bytes
+		// Total: 8 + 2 + 6 + 0 = 16 bytes
+		expect(size).toBe(16);
+	});
+
+	it("calculates size for record with no headers", () => {
+		const record = AppendRecord.make.string("hello");
+
+		const size = meteredSizeBytes(record);
+
+		// body: "hello" = 5 bytes
+		// headers: 0 bytes
+		// overhead: 8 + 2*0 = 8 bytes
+		// Total: 8 + 0 + 0 + 5 = 13 bytes
+		expect(size).toBe(13);
+	});
+
+	it("calculates size for empty record", () => {
+		const record = AppendRecord.make.string();
+
+		const size = meteredSizeBytes(record);
+
+		// body: 0 bytes
+		// headers: 0 bytes
+		// overhead: 8 + 2*0 = 8 bytes
+		// Total: 8 bytes
+		expect(size).toBe(8);
+	});
+
+	it("calculates size for command records", () => {
+		const fenceRecord = AppendRecord.fence.string("my-token");
+		const size = meteredSizeBytes(fenceRecord);
+
+		// body: "my-token" = 8 bytes
+		// headers: "" = 0, "fence" = 5 = 5 bytes
+		// overhead: 8 + 2*1 (1 header) = 10 bytes
+		// Total: 8 + 2 + 5 + 8 = 23 bytes
+		expect(size).toBe(23);
+	});
+
+	it("calculates size for trim command (bytes format)", () => {
+		const trimRecord = AppendRecord.trim(123);
+		const size = meteredSizeBytes(trimRecord);
+
+		// body: 8 bytes (BigInt as Uint8Array)
+		// headers: empty Uint8Array = 0, "trim" as bytes = 4 = 4 bytes
+		// overhead: 8 + 2*1 (1 header) = 10 bytes
+		// Total: 8 + 2 + 4 + 8 = 22 bytes
+		expect(size).toBe(22);
+	});
+});

--- a/src/tests/meteredSize.test.ts
+++ b/src/tests/meteredSize.test.ts
@@ -3,7 +3,7 @@ import { AppendRecord, meteredSizeBytes } from "../utils.js";
 
 describe("meteredSizeBytes", () => {
 	it("calculates size for string format records", () => {
-		const record = AppendRecord.make.string("hello", {
+		const record = AppendRecord.make("hello", {
 			foo: "bar",
 			baz: "qux",
 		});
@@ -18,7 +18,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for string format with UTF-8 characters", () => {
-		const record = AppendRecord.make.string("hello 世界", {
+		const record = AppendRecord.make("hello 世界", {
 			emoji: "🚀",
 		});
 
@@ -32,7 +32,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for bytes format records", () => {
-		const record = AppendRecord.make.bytes(new Uint8Array([1, 2, 3, 4, 5]), [
+		const record = AppendRecord.make(new Uint8Array([1, 2, 3, 4, 5]), [
 			[new Uint8Array([10, 20]), new Uint8Array([30, 40, 50])],
 		]);
 
@@ -46,7 +46,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for record with no body", () => {
-		const record = AppendRecord.make.string(undefined, {
+		const record = AppendRecord.make(undefined, {
 			foo: "bar",
 		});
 
@@ -60,7 +60,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for record with no headers", () => {
-		const record = AppendRecord.make.string("hello");
+		const record = AppendRecord.make("hello");
 
 		const size = meteredSizeBytes(record);
 
@@ -72,7 +72,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for empty record", () => {
-		const record = AppendRecord.make.string();
+		const record = AppendRecord.make();
 
 		const size = meteredSizeBytes(record);
 
@@ -84,7 +84,7 @@ describe("meteredSizeBytes", () => {
 	});
 
 	it("calculates size for command records", () => {
-		const fenceRecord = AppendRecord.fence.string("my-token");
+		const fenceRecord = AppendRecord.fence("my-token");
 		const size = meteredSizeBytes(fenceRecord);
 
 		// body: "my-token" = 8 bytes

--- a/src/tests/utf8ByteLength.test.ts
+++ b/src/tests/utf8ByteLength.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { utf8ByteLength } from "../utils.js";
+
+describe("utf8ByteLength", () => {
+	// Helper to get actual UTF-8 byte length using TextEncoder
+	const actualByteLength = (str: string): number => {
+		return new TextEncoder().encode(str).length;
+	};
+
+	it("calculates byte length for ASCII characters (1 byte each)", () => {
+		const testCases = [
+			"",
+			"a",
+			"hello",
+			"Hello, World!",
+			"0123456789",
+			"ASCII only: !@#$%^&*()",
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for Latin-1 Supplement characters (2 bytes)", () => {
+		const testCases = [
+			"café", // é = U+00E9 (2 bytes)
+			"naïve", // ï = U+00EF (2 bytes)
+			"Zürich", // ü = U+00FC (2 bytes)
+			"€100", // € = U+20AC (3 bytes actually, but testing mixed)
+			"©2024", // © = U+00A9 (2 bytes)
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for CJK characters (3 bytes each)", () => {
+		const testCases = [
+			"世界", // Chinese: 2 chars × 3 bytes = 6 bytes
+			"日本語", // Japanese: 3 chars × 3 bytes = 9 bytes
+			"한글", // Korean: 2 chars × 3 bytes = 6 bytes
+			"你好世界", // Chinese: 4 chars × 3 bytes = 12 bytes
+			"hello 世界", // Mixed: 6 ASCII (6 bytes) + 2 CJK (6 bytes) = 12 bytes
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for emoji (4 bytes via surrogate pairs)", () => {
+		const testCases = [
+			"🚀", // U+1F680 (surrogate pair: 4 bytes)
+			"😀", // U+1F600 (surrogate pair: 4 bytes)
+			"🎉", // U+1F389 (surrogate pair: 4 bytes)
+			"👍", // U+1F44D (surrogate pair: 4 bytes)
+			"🌟", // U+1F31F (surrogate pair: 4 bytes)
+			"hello 🚀", // 6 ASCII + 4 emoji = 10 bytes
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for multiple emoji", () => {
+		const testCases = [
+			"🚀🎉", // 2 emoji × 4 bytes = 8 bytes
+			"😀😃😄", // 3 emoji × 4 bytes = 12 bytes
+			"🌍🌎🌏", // 3 emoji × 4 bytes = 12 bytes
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for mixed Unicode content", () => {
+		const testCases = [
+			"Hello 世界 🚀", // ASCII + CJK + emoji
+			"Café ☕ 日本", // Latin + emoji + CJK
+			"Price: €50 💰", // ASCII + currency + emoji
+			"2024年 🎉", // ASCII + CJK + emoji
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for Arabic and RTL text (3 bytes)", () => {
+		const testCases = [
+			"مرحبا", // Arabic: 5 chars × ~3 bytes (varies)
+			"שלום", // Hebrew: 4 chars × ~3 bytes
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("calculates byte length for special Unicode characters", () => {
+		const testCases = [
+			"™", // U+2122 (3 bytes)
+			"®", // U+00AE (2 bytes)
+			"°", // U+00B0 (2 bytes)
+			"±", // U+00B1 (2 bytes)
+			"×", // U+00D7 (2 bytes)
+			"÷", // U+00F7 (2 bytes)
+			"π", // U+03C0 (2 bytes)
+			"∞", // U+221E (3 bytes)
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("handles empty string", () => {
+		expect(utf8ByteLength("")).toBe(0);
+		expect(utf8ByteLength("")).toBe(actualByteLength(""));
+	});
+
+	it("handles newlines and whitespace", () => {
+		const testCases = [
+			"\n",
+			"\r\n",
+			"\t",
+			"  ",
+			"hello\nworld",
+			"line1\r\nline2",
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("handles very long strings", () => {
+		const longAscii = "a".repeat(10000);
+		expect(utf8ByteLength(longAscii)).toBe(actualByteLength(longAscii));
+
+		const longUnicode = "世".repeat(1000);
+		expect(utf8ByteLength(longUnicode)).toBe(actualByteLength(longUnicode));
+
+		const longEmoji = "🚀".repeat(500);
+		expect(utf8ByteLength(longEmoji)).toBe(actualByteLength(longEmoji));
+	});
+
+	it("handles strings with null bytes", () => {
+		const testCases = ["hello\x00world", "\x00", "start\x00middle\x00end"];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	it("handles all ASCII printable characters", () => {
+		// ASCII printable: space (32) to tilde (126)
+		const allPrintable = Array.from({ length: 95 }, (_, i) =>
+			String.fromCharCode(32 + i),
+		).join("");
+		expect(utf8ByteLength(allPrintable)).toBe(actualByteLength(allPrintable));
+	});
+
+	it("handles boundary cases for UTF-8 encoding", () => {
+		// U+007F: Last 1-byte character
+		expect(utf8ByteLength("\x7F")).toBe(actualByteLength("\x7F"));
+
+		// U+0080: First 2-byte character
+		expect(utf8ByteLength("\u0080")).toBe(actualByteLength("\u0080"));
+
+		// U+07FF: Last 2-byte character
+		expect(utf8ByteLength("\u07FF")).toBe(actualByteLength("\u07FF"));
+
+		// U+0800: First 3-byte character
+		expect(utf8ByteLength("\u0800")).toBe(actualByteLength("\u0800"));
+
+		// U+FFFF: Last 3-byte character (BMP)
+		expect(utf8ByteLength("\uFFFF")).toBe(actualByteLength("\uFFFF"));
+	});
+
+	it("handles complex emoji with modifiers and ZWJ sequences", () => {
+		const testCases = [
+			"👨‍👩‍👧‍👦", // Family emoji (ZWJ sequence)
+			"👋🏽", // Waving hand with skin tone modifier
+			"🏳️‍🌈", // Rainbow flag (ZWJ sequence)
+		];
+
+		for (const str of testCases) {
+			expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+		}
+	});
+
+	// Edge case: unpaired surrogates
+	// Note: These are technically invalid UTF-16, but JavaScript allows them
+	it("handles unpaired high surrogate (3 bytes replacement)", () => {
+		// Manually create an unpaired high surrogate
+		const unpairedHigh = String.fromCharCode(0xd800); // High surrogate without pair
+		expect(utf8ByteLength(unpairedHigh)).toBe(actualByteLength(unpairedHigh));
+	});
+
+	it("handles unpaired low surrogate (3 bytes replacement)", () => {
+		// Manually create an unpaired low surrogate
+		const unpairedLow = String.fromCharCode(0xdc00); // Low surrogate without pair
+		expect(utf8ByteLength(unpairedLow)).toBe(actualByteLength(unpairedLow));
+	});
+
+	it("handles unpaired high surrogate at end of string", () => {
+		const str = "hello" + String.fromCharCode(0xd800); // High surrogate at end
+		expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+	});
+
+	it("handles unpaired high surrogate followed by non-surrogate", () => {
+		const str = String.fromCharCode(0xd800) + "a"; // High surrogate + ASCII
+		expect(utf8ByteLength(str)).toBe(actualByteLength(str));
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ function appendRecordCommand(
 		if (typeof command === "string") {
 			return [["", command]];
 		}
-		return [new TextEncoder().encode(""), command];
+		return [[new TextEncoder().encode(""), command]];
 	})();
 	// safety: we know the types are correct because of the overloads
 	return AppendRecord.make(body as any, headers as any, timestamp);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,11 @@
-import type { AppendRecord as AppendRecordType } from "./stream.js";
+import type {
+	AppendRecord as AppendRecordType,
+	BytesAppendRecord,
+	StringAppendRecord,
+} from "./stream.js";
 
-type Headers =
-	| Record<string, string>
-	| Array<[string | Uint8Array, string | Uint8Array]>;
+type StringHeaders = Record<string, string> | Array<[string, string]>;
+type BytesHeaders = Array<[Uint8Array, Uint8Array]>;
 
 export type AppendRecord = AppendRecordType;
 
@@ -16,65 +19,167 @@ export type AppendRecord = AppendRecordType;
  * - `trim` is a command record that encodes a sequence number for trimming
  */
 export const AppendRecord = {
-	make: (
-		body?: string | Uint8Array,
-		headers?: Headers,
-		timestamp?: AppendRecordType["timestamp"],
-	): AppendRecordType => {
-		return {
-			body,
-			headers,
-			timestamp,
-		};
+	make: {
+		string: (
+			body?: string,
+			headers?: StringHeaders,
+			timestamp?: number,
+		): StringAppendRecord => {
+			return {
+				format: "string",
+				body,
+				headers,
+				timestamp,
+			};
+		},
+		bytes: (
+			body?: Uint8Array,
+			headers?: BytesHeaders,
+			timestamp?: number,
+		): BytesAppendRecord => {
+			return {
+				format: "bytes",
+				body,
+				headers,
+				timestamp,
+			};
+		},
 	},
-	command: (
-		/** Command name (e.g. "fence" or "trim"). */
-		command: string,
-		body?: string | Uint8Array,
-		additionalHeaders?: Headers,
-		timestamp?: AppendRecordType["timestamp"],
-	): AppendRecordType => {
-		const headers: AppendRecordType["headers"] = (() => {
-			if (!additionalHeaders) {
-				return [["", command]];
-			} else if (Array.isArray(additionalHeaders)) {
-				return [["", command] as [string, string], ...additionalHeaders];
-			} else {
-				return [
-					["", command] as [string, string],
-					...Object.entries(additionalHeaders).map(
-						([key, value]) => [key, value] as [string, string],
-					),
-				];
-			}
-		})();
-		return {
-			body,
-			headers,
-			timestamp,
-		};
+	command: {
+		string: (
+			/** Command name (e.g. "fence" or "trim"). */
+			command: string,
+			body?: string,
+			timestamp?: number,
+		): StringAppendRecord => {
+			const headers: Array<[string, string]> = [["", command]];
+			return {
+				format: "string",
+				body,
+				headers,
+				timestamp,
+			};
+		},
+		bytes: (
+			/** Command name (e.g. "fence" or "trim"). */
+			command: string,
+			body?: Uint8Array,
+			timestamp?: number,
+		): BytesAppendRecord => {
+			const headers: BytesHeaders = [
+				[new Uint8Array(), new TextEncoder().encode(command)],
+			];
+			return {
+				format: "bytes",
+				body,
+				headers,
+				timestamp,
+			};
+		},
 	},
-	fence: (
-		fencing_token: string,
-		additionalHeaders?: Headers,
-		timestamp?: AppendRecordType["timestamp"],
-	) => {
-		return AppendRecord.command(
-			"fence",
-			fencing_token,
-			additionalHeaders,
-			timestamp,
-		);
+	fence: {
+		string: (fencing_token: string, timestamp?: number): StringAppendRecord => {
+			return AppendRecord.command.string("fence", fencing_token, timestamp);
+		},
+		bytes: (fencing_token: string, timestamp?: number): BytesAppendRecord => {
+			return AppendRecord.command.bytes(
+				"fence",
+				new TextEncoder().encode(fencing_token),
+				timestamp,
+			);
+		},
 	},
-	trim: (
-		seqNum: number | bigint,
-		additionalHeaders?: Headers,
-		timestamp?: AppendRecordType["timestamp"],
-	): AppendRecordType => {
+	trim: (seqNum: number | bigint, timestamp?: number): BytesAppendRecord => {
 		// Encode sequence number as 8 big-endian bytes
 		const buffer = new Uint8Array(8);
 		const view = new DataView(buffer.buffer);
 		view.setBigUint64(0, BigInt(seqNum), false); // false = big-endian
-		return AppendRecord.command("trim", buffer, additionalHeaders, timestamp);
+		return AppendRecord.command.bytes("trim", buffer, timestamp);
 	},
 } as const;
+
+/**
+ * Calculate the UTF-8 byte length of a string.
+ * Handles all Unicode characters including surrogate pairs correctly.
+ *
+ * @param str The string to measure
+ * @returns The byte length when encoded as UTF-8
+ */
+export function utf8ByteLength(str: string): number {
+	let bytes = 0;
+	for (let i = 0; i < str.length; i++) {
+		const code = str.charCodeAt(i);
+
+		if (code <= 0x7f) {
+			bytes += 1;
+		} else if (code <= 0x7ff) {
+			bytes += 2;
+		} else if (code >= 0xd800 && code <= 0xdbff) {
+			// high surrogate
+			if (i + 1 < str.length) {
+				const next = str.charCodeAt(i + 1);
+				if (next >= 0xdc00 && next <= 0xdfff) {
+					// valid surrogate pair → 4 bytes in UTF-8
+					bytes += 4;
+					i++; // skip low surrogate
+				} else {
+					// unpaired high surrogate → treat as 3 bytes (replacement-style)
+					bytes += 3;
+				}
+			} else {
+				// unpaired high surrogate at end of string
+				bytes += 3;
+			}
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			// lone low surrogate — treat as 3 bytes
+			bytes += 3;
+		} else {
+			bytes += 3;
+		}
+	}
+	return bytes;
+}
+
+/**
+ * Calculate the metered size in bytes of an AppendRecord.
+ * This includes the body and headers, but not metadata like timestamp.
+ *
+ * @param record The record to measure
+ * @returns The size in bytes
+ */
+export function meteredSizeBytes(record: AppendRecordType): number {
+	if (record.format === "string") {
+		const numHeaders = record.headers
+			? Array.isArray(record.headers)
+				? record.headers.length
+				: Object.keys(record.headers).length
+			: 0;
+		const headers = (() => {
+			if (record.headers) {
+				if (Array.isArray(record.headers)) {
+					return record.headers
+						.map(([k, v]) => utf8ByteLength(k) + utf8ByteLength(v))
+						.reduce((a, b) => a + b, 0);
+				} else {
+					return Object.entries(record.headers)
+						.map(([k, v]) => utf8ByteLength(k) + utf8ByteLength(v))
+						.reduce((a, b) => a + b, 0);
+				}
+			} else {
+				return 0;
+			}
+		})();
+		const body = record.body ? utf8ByteLength(record.body) : 0;
+
+		return 8 + 2 * numHeaders + headers + body;
+	} else {
+		const numHeaders = record.headers?.length ?? 0;
+		const headers =
+			record.headers
+				?.map(([k, v]) => k.length + v.length)
+				.reduce((a, b) => a + b, 0) ?? 0;
+		const body = record.body?.length ?? 0;
+
+		return 8 + 2 * numHeaders + headers + body;
+	}
+}


### PR DESCRIPTION
Closes #17 

Also enforces that an `AppendSession` / `Batcher` consume only `StringAppendRecord` or `BytesAppendRecord` (all header kv pairs and body get base64'd)

Also:
- Creates a new batcher, not tied to an append session
- Batcher will throw when submitting any single record that exceeds max batch size in bytes
- WritableStream backpressure via append session's `submit` which now blocks on there being enough space in the queue

example use
```typescript

function createStringStream(
	n: number,
	delayMs: number = 0,
): ReadableStream<string> {
// ...
}

const pipe = await stringStream
	.pipeThrough(
		new TransformStream<string, AppendRecord>({
			transform(str, controller) {
				controller.enqueue(AppendRecord.make.string(str));
			},
		}),
	)
	.pipeThrough(
		new BatchTransform<"string">({
			lingerDuration: 1000,
			maxBatchRecords: 10,
		}),
	)
	.pipeTo(await stream.appendSession("string"));
```