### PR TITLE
tweaks, additional example

### DIFF
--- a/examples/append.ts
+++ b/examples/append.ts
@@ -28,7 +28,7 @@ if (streams.streams[0]) {
 
 	// Create a batcher that will batch records
 	const batcher = new BatchTransform({
-		lingerDuration: 20,
+		lingerDurationMillis: 20,
 		maxBatchRecords: 10,
 	});
 

--- a/examples/image.ts
+++ b/examples/image.ts
@@ -1,0 +1,113 @@
+import { createWriteStream } from "node:fs";
+import {
+	AppendRecord,
+	BatchTransform,
+	type ReadRecord,
+	S2,
+} from "../src/index.js";
+
+function rechunkStream(
+	desiredChunkSize: number,
+): TransformStream<Uint8Array, Uint8Array> {
+	let buffer = new Uint8Array(0);
+	return new TransformStream({
+		transform(chunk, controller) {
+			const newBuffer = new Uint8Array(buffer.length + chunk.length);
+			newBuffer.set(buffer);
+			newBuffer.set(chunk, buffer.length);
+			buffer = newBuffer;
+			while (buffer.length >= desiredChunkSize) {
+				controller.enqueue(buffer.slice(0, desiredChunkSize));
+				buffer = buffer.slice(desiredChunkSize);
+			}
+		},
+		flush(controller) {
+			if (buffer.length > 0) {
+				controller.enqueue(buffer);
+			}
+		},
+	});
+}
+
+const s2 = new S2({
+	accessToken: process.env.S2_ACCESS_TOKEN!,
+});
+
+const basin = s2.basin("demo-10202025");
+const stream = basin.stream("image");
+
+const startAt = await stream.checkTail();
+
+const session = await stream.appendSession({
+	maxQueuedBytes: 1024 * 1024 * 10,
+});
+let image = await fetch(
+	"https://upload.wikimedia.org/wikipedia/commons/2/24/Peter_Paul_Rubens_-_Self-portrait_-_RH.S.180_-_Rubenshuis_%28after_restoration%29.jpg",
+);
+
+// Write directly from fetch response to S2 stream
+let append = await image
+	.body! // Ensure each chunk is at most 128KiB. S2 has a maximum individual record size of 1MiB.
+	.pipeThrough(rechunkStream(1024 * 128))
+	// Convert each chunk to an AppendRecord.
+	.pipeThrough(
+		new TransformStream<Uint8Array, AppendRecord>({
+			transform(arr, controller) {
+				controller.enqueue(AppendRecord.make(arr));
+			},
+		}),
+	)
+	// Collect records into batches.
+	.pipeThrough(new BatchTransform({ lingerDurationMillis: 50, match_seq_num: startAt.tail.seq_num }))
+	// Write to the S2 stream.
+	.pipeTo(session.writable);
+
+console.log(
+	`image written to S2 over ${session.lastAckedPosition()!.end!.seq_num - startAt.tail.seq_num} records, starting at seqNum=${startAt.tail.seq_num}`,
+);
+
+
+let readSession = await stream.readSession({
+	seq_num: startAt.tail.seq_num,
+	count: session.lastAckedPosition()!.end!.seq_num - startAt.tail.seq_num,
+	as: "bytes",
+});
+
+// Write to a local file.
+const id = Math.random().toString(36).slice(2, 10);
+// Use a larger buffer (default is 16KB, we use 512KB)
+const out = createWriteStream(`image-${id}.jpg`, {
+	highWaterMark: 512 * 1024 // 512KB buffer
+});
+
+await readSession
+	.pipeThrough(
+		new TransformStream<ReadRecord<"bytes">, Uint8Array>({
+			transform(arr, controller) {
+				controller.enqueue(arr.body);
+			},
+		}),
+	)
+	.pipeTo(
+		new WritableStream({
+			async write(chunk) {
+				// Handle backpressure - wait if buffer is full
+				if (!out.write(chunk)) {
+					await new Promise<void>((resolve) => out.once('drain', resolve));
+				}
+			},
+			// Don't close here - we'll close manually after to ensure flush
+		}),
+	);
+
+// Ensure the file is fully written and closed before exiting
+await new Promise<void>((resolve, reject) => {
+	out.close((err) => {
+		if (err) reject(err);
+		else resolve();
+	});
+});
+
+console.log(`Image written to image-${id}.jpg`);
+
+process.exit(0);

--- a/examples/image.ts
+++ b/examples/image.ts
@@ -33,7 +33,13 @@ const s2 = new S2({
 	accessToken: process.env.S2_ACCESS_TOKEN!,
 });
 
-const basin = s2.basin("demo-10202025");
+const basinName = process.env.S2_BASIN;
+if (!basinName) {
+	console.error("S2_BASIN environment variable is not set");
+	process.exit(1);
+}
+
+const basin = s2.basin(process.env.S2_BASIN!);
 const stream = basin.stream("image");
 
 const startAt = await stream.checkTail();

--- a/src/batch-transform.ts
+++ b/src/batch-transform.ts
@@ -3,10 +3,10 @@ import { AppendRecord, meteredSizeBytes } from "./utils.js";
 
 export interface BatchTransformArgs {
 	/** Duration in milliseconds to wait before flushing a batch (default: 5ms) */
-	lingerDuration?: number;
+	lingerDurationMillis?: number;
 	/** Maximum number of records in a batch (default: 1000, max: 1000) */
 	maxBatchRecords?: number;
-	/** Maximum batch size in bytes (default: 1 MiB, max: 1 MiB) */
+	/** Maximum batch size in metered bytes (default: 1 MiB, max: 1 MiB) */
 	maxBatchBytes?: number;
 	/** Optional fencing token to enforce (remains static across batches) */
 	fencing_token?: string;
@@ -86,7 +86,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 			args?.maxBatchBytes ?? 1024 * 1024,
 			1024 * 1024,
 		);
-		this.lingerDuration = args?.lingerDuration ?? 5;
+		this.lingerDuration = args?.lingerDurationMillis ?? 5;
 		this.fencing_token = args?.fencing_token;
 		this.next_match_seq_num = args?.match_seq_num;
 	}

--- a/src/lib/stream/transport/s2s/index.ts
+++ b/src/lib/stream/transport/s2s/index.ts
@@ -118,10 +118,21 @@ export class S2STransport implements SessionTransport {
 						// TLS options can go here if needed
 					}
 				: {}),
+			// HTTP/2 settings for high-throughput streaming
+			settings: {
+				// Increase initial window size from default 64KB to 10MB
+				// This allows more data to be in-flight before flow control blocks
+				initialWindowSize: 10 * 1024 * 1024, // 10 MB
+				// Allow more concurrent streams
+				maxConcurrentStreams: 100,
+			},
 		});
 
 		return new Promise((resolve, reject) => {
 			client.once("connect", () => {
+				// Increase connection-level flow control window to 10MB
+				// This is separate from per-stream window and prevents connection-level blocking
+				client.setLocalWindowSize(10 * 1024 * 1024);
 				resolve(client);
 			});
 

--- a/src/lib/stream/transport/s2s/index.ts
+++ b/src/lib/stream/transport/s2s/index.ts
@@ -118,20 +118,13 @@ export class S2STransport implements SessionTransport {
 						// TLS options can go here if needed
 					}
 				: {}),
-			// HTTP/2 settings for high-throughput streaming
 			settings: {
-				// Increase initial window size from default 64KB to 10MB
-				// This allows more data to be in-flight before flow control blocks
 				initialWindowSize: 10 * 1024 * 1024, // 10 MB
-				// Allow more concurrent streams
-				maxConcurrentStreams: 100,
 			},
 		});
 
 		return new Promise((resolve, reject) => {
 			client.once("connect", () => {
-				// Increase connection-level flow control window to 10MB
-				// This is separate from per-stream window and prevents connection-level blocking
 				client.setLocalWindowSize(10 * 1024 * 1024);
 				resolve(client);
 			});

--- a/src/tests/batch-transform.test.ts
+++ b/src/tests/batch-transform.test.ts
@@ -5,7 +5,7 @@ import { S2Error } from "../error.js";
 describe("BatchTransform", () => {
 	it("batches records based on linger duration", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 50,
+			lingerDurationMillis: 50,
 			maxBatchRecords: 100,
 		});
 
@@ -34,7 +34,7 @@ describe("BatchTransform", () => {
 
 	it("flushes immediately when max records reached", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000, // Long linger, should flush before this
+			lingerDurationMillis: 1000, // Long linger, should flush before this
 			maxBatchRecords: 2,
 		});
 
@@ -64,7 +64,7 @@ describe("BatchTransform", () => {
 
 	it("flushes when max bytes reached", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000,
+			lingerDurationMillis: 1000,
 			maxBatchBytes: 30, // Small batch size
 		});
 
@@ -97,7 +97,7 @@ describe("BatchTransform", () => {
 
 	it("flushes remaining records on close", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10000, // Very long linger
+			lingerDurationMillis: 10000, // Very long linger
 			maxBatchRecords: 100,
 		});
 
@@ -126,7 +126,7 @@ describe("BatchTransform", () => {
 
 	it("works with bytes format", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 50,
+			lingerDurationMillis: 50,
 		});
 
 		const writer = batcher.writable.getWriter();
@@ -147,7 +147,7 @@ describe("BatchTransform", () => {
 
 	it("can be used with pipeTo", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 		});
 
 		// Create a readable stream of records
@@ -181,7 +181,7 @@ describe("BatchTransform", () => {
 
 	it("handles rapid writes with linger", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 20,
+			lingerDurationMillis: 20,
 			maxBatchRecords: 10,
 		});
 
@@ -223,7 +223,7 @@ describe("BatchTransform", () => {
 
 	it("handles empty batches gracefully", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 		});
 
 		const writer = batcher.writable.getWriter();
@@ -241,7 +241,7 @@ describe("BatchTransform", () => {
 
 	it("cancels linger timer when batch is flushed early", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000, // Long linger
+			lingerDurationMillis: 1000, // Long linger
 			maxBatchRecords: 2,
 		});
 
@@ -274,7 +274,7 @@ describe("BatchTransform", () => {
 
 	it("works in a for-await loop", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 		});
 
 		const writer = batcher.writable.getWriter();
@@ -358,7 +358,7 @@ describe("BatchTransform", () => {
 
 	it("includes fencing_token in batch output", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 			fencing_token: "my-fence-token",
 		});
 
@@ -382,7 +382,7 @@ describe("BatchTransform", () => {
 
 	it("auto-increments match_seq_num across batches", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 			maxBatchRecords: 2,
 			match_seq_num: 0, // Start at 0
 		});
@@ -425,7 +425,7 @@ describe("BatchTransform", () => {
 
 	it("works without fencing_token or match_seq_num", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 		});
 
 		const writer = batcher.writable.getWriter();

--- a/src/tests/batcher-session.test.ts
+++ b/src/tests/batcher-session.test.ts
@@ -38,7 +38,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		streamAppendSpy.mockResolvedValue(makeAck(1));
 
 		const batcher = new BatchTransform({
-			lingerDuration: 10,
+			lingerDurationMillis: 10,
 			maxBatchRecords: 100,
 		});
 
@@ -65,7 +65,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		streamAppendSpy.mockResolvedValueOnce(makeAck(2));
 
 		const batcher = new BatchTransform({
-			lingerDuration: 0,
+			lingerDurationMillis: 0,
 			maxBatchRecords: 2,
 			match_seq_num: 5,
 		});
@@ -96,7 +96,7 @@ describe("BatchTransform + AppendSession integration", () => {
 		streamAppendSpy.mockResolvedValue(makeAck(123));
 
 		const batcher = new BatchTransform({
-			lingerDuration: 0,
+			lingerDurationMillis: 0,
 			maxBatchRecords: 10,
 		});
 

--- a/src/tests/batcher.test.ts
+++ b/src/tests/batcher.test.ts
@@ -5,7 +5,7 @@ import { S2Error } from "../error.js";
 describe("BatchTransform", () => {
 	it("close() flushes remaining records", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000,
+			lingerDurationMillis: 1000,
 			maxBatchRecords: 10,
 		});
 
@@ -27,7 +27,7 @@ describe("BatchTransform", () => {
 
 	it("propagates fencing_token and auto-increments match_seq_num across batches", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 0,
+			lingerDurationMillis: 0,
 			maxBatchRecords: 2,
 			fencing_token: "ft",
 			match_seq_num: 10,
@@ -65,7 +65,7 @@ describe("BatchTransform", () => {
 
 	it("flushes immediately when max records reached", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000, // Long linger
+			lingerDurationMillis: 1000, // Long linger
 			maxBatchRecords: 2,
 		});
 
@@ -95,7 +95,7 @@ describe("BatchTransform", () => {
 
 	it("flushes when max bytes reached", async () => {
 		const batcher = new BatchTransform({
-			lingerDuration: 1000,
+			lingerDurationMillis: 1000,
 			maxBatchBytes: 30, // Small batch size
 		});
 


### PR DESCRIPTION
- naming: clarify linger is `ms`
- http/2: change window settings in support of higher throughput when using s2s transport
- example: add an example of http fetch of an image -> s2 stream, followed by a read from the s2 stream -> image file locally