### PR TITLE
fix: add protobuf runtime dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.17.1] - 2025-11-04
+
+### 🐛 Bug Fixes
+
+- Add protobuf runtime dep
+- dda2cb9: batch linger naming change
+
 # @s2-dev/streamstore
 
 ## 0.17.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2-dev/streamstore",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "README.md",
     "LICENSE"
   ],
+  "dependencies": {
+    "@protobuf-ts/runtime": "^2.11.1"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@biomejs/biome": "2.2.5",


### PR DESCRIPTION
The codegen uses types that rely on the proto runtime package being present.