### PR TITLE
fix: add missing timestamp field when sending batch records

### DIFF
--- a/src/lib/stream/transport/s2s/index.ts
+++ b/src/lib/stream/transport/s2s/index.ts
@@ -779,6 +779,7 @@ class S2SAppendSession
 				}
 
 				return {
+					timestamp: record.timestamp ? BigInt(record.timestamp) : undefined,
 					headers: headersArray?.map((h) => ({
 						name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
 						value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],
@@ -864,6 +865,7 @@ class S2SAppendSession
 				}
 
 				return {
+					timestamp: record.timestamp ? BigInt(record.timestamp) : undefined,
 					headers: headersArray?.map((h) => ({
 						name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
 						value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],


### PR DESCRIPTION
Noticed an issue where client-side timestamps where not being used when
writing to the stream, even though the basin is configured with `client-prefer` timestamping.

It appears the issue is the mapping to protobuf step in both `sendBatch` and `sendBatchNonBlocking`.
Should be fixed in this PR.
