### PR TITLE
fix: matchSeqNum=0 represented as unset in proto

### DIFF
--- a/src/lib/stream/transport/s2s/index.ts
+++ b/src/lib/stream/transport/s2s/index.ts
@@ -35,6 +35,42 @@ import type {
 } from "../../types.js";
 import { frameMessage, S2SFrameParser } from "./framing.js";
 
+export function buildProtoAppendInput(
+	records: AppendRecord[],
+	args: AppendArgs,
+): ProtoAppendInput {
+	const textEncoder = new TextEncoder();
+	return ProtoAppendInput.create({
+		records: records.map((record) => {
+			let headersArray:
+				| Array<[string, string]>
+				| Array<[Uint8Array, Uint8Array]>
+				| undefined;
+			if (record.headers) {
+				if (Array.isArray(record.headers)) {
+					headersArray = record.headers;
+				} else {
+					headersArray = Object.entries(record.headers);
+				}
+			}
+
+			return {
+				headers: headersArray?.map((h) => ({
+					name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
+					value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],
+				})),
+				body:
+					typeof record.body === "string"
+						? textEncoder.encode(record.body)
+						: record.body,
+			};
+		}),
+		fencingToken: args.fencing_token ?? undefined,
+		matchSeqNum:
+			args.match_seq_num == null ? undefined : BigInt(args.match_seq_num),
+	});
+}
+
 export class S2STransport implements SessionTransport {
 	private readonly client: Client;
 	private readonly transportConfig: TransportConfig;
@@ -761,38 +797,7 @@ class S2SAppendSession
 		}
 
 		// Convert to protobuf AppendInput
-		const textEncoder = new TextEncoder();
-		const protoInput = ProtoAppendInput.create({
-			records: records.map((record) => {
-				// Convert headers to array of tuples if it's a Record
-				let headersArray:
-					| Array<[string, string]>
-					| Array<[Uint8Array, Uint8Array]>
-					| undefined;
-				if (record.headers) {
-					if (Array.isArray(record.headers)) {
-						headersArray = record.headers;
-					} else {
-						// Convert Record to array of tuples
-						headersArray = Object.entries(record.headers);
-					}
-				}
-
-				return {
-					timestamp: record.timestamp ? BigInt(record.timestamp) : undefined,
-					headers: headersArray?.map((h) => ({
-						name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
-						value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],
-					})),
-					body:
-						typeof record.body === "string"
-							? textEncoder.encode(record.body)
-							: record.body,
-				};
-			}),
-			fencingToken: args.fencing_token ?? undefined,
-			matchSeqNum: args.match_seq_num ? BigInt(args.match_seq_num) : undefined,
-		});
+		const protoInput = buildProtoAppendInput(records, args);
 
 		const bodyBytes = ProtoAppendInput.toBinary(protoInput);
 
@@ -847,38 +852,7 @@ class S2SAppendSession
 		}
 
 		// Convert to protobuf AppendInput
-		const textEncoder = new TextEncoder();
-		const protoInput = ProtoAppendInput.create({
-			records: records.map((record) => {
-				// Convert headers to array of tuples if it's a Record
-				let headersArray:
-					| Array<[string, string]>
-					| Array<[Uint8Array, Uint8Array]>
-					| undefined;
-				if (record.headers) {
-					if (Array.isArray(record.headers)) {
-						headersArray = record.headers;
-					} else {
-						// Convert Record to array of tuples
-						headersArray = Object.entries(record.headers);
-					}
-				}
-
-				return {
-					timestamp: record.timestamp ? BigInt(record.timestamp) : undefined,
-					headers: headersArray?.map((h) => ({
-						name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
-						value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],
-					})),
-					body:
-						typeof record.body === "string"
-							? textEncoder.encode(record.body)
-							: record.body,
-				};
-			}),
-			fencingToken: args.fencing_token ?? undefined,
-			matchSeqNum: args.match_seq_num ? BigInt(args.match_seq_num) : undefined,
-		});
+		const protoInput = buildProtoAppendInput(records, args);
 
 		const bodyBytes = ProtoAppendInput.toBinary(protoInput);
 

--- a/src/lib/stream/transport/s2s/index.ts
+++ b/src/lib/stream/transport/s2s/index.ts
@@ -55,6 +55,7 @@ export function buildProtoAppendInput(
 			}
 
 			return {
+				timestamp: record.timestamp ? BigInt(record.timestamp) : undefined,
 				headers: headersArray?.map((h) => ({
 					name: typeof h[0] === "string" ? textEncoder.encode(h[0]) : h[0],
 					value: typeof h[1] === "string" ? textEncoder.encode(h[1]) : h[1],

--- a/src/tests/s2s-transport.test.ts
+++ b/src/tests/s2s-transport.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildProtoAppendInput } from "../lib/stream/transport/s2s/index.js";
+import type { AppendArgs, AppendRecord } from "../lib/stream/types.js";
+
+const makeRecords = (): AppendRecord[] => [{ body: "hello" }];
+
+describe("S2S transport proto serialization", () => {
+	it("encodes match_seq_num = 0 instead of dropping it", () => {
+		const records = makeRecords();
+		const args: AppendArgs = {
+			records,
+			match_seq_num: 0,
+		};
+
+		const proto = buildProtoAppendInput(records, args);
+
+		expect(proto.matchSeqNum).toBe(0n);
+	});
+
+	it("omits match_seq_num when it is undefined", () => {
+		const records = makeRecords();
+		const args: AppendArgs = {
+			records,
+		};
+
+		const proto = buildProtoAppendInput(records, args);
+
+		expect(proto.matchSeqNum).toBeUndefined();
+	});
+});


### PR DESCRIPTION
When using an s2s append session, and explicitly setting a `match_seq_num=0`, this was getting represented in proto as an undefined `match_seq_num`, thus dropping the condition.