### PR TITLE
chore: change default append retry policy to `all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The `S2` client and stream sessions support configurable retry behavior:
       maxAttempts: 3,
       // Base delay (ms) between attempts; jitter is applied
       retryBackoffDurationMillis: 100,
-      // Retry policy for append operations (see API docs for details)
-      appendRetryPolicy: "noSideEffects",
+      // Retry policy for append operations (default: "all"; see API docs for details)
+      appendRetryPolicy: "all",
       // Maximum time (ms) to wait for an append ack before treating it as failed
       requestTimeoutMillis: 5000,
     },
@@ -79,7 +79,7 @@ The `S2` client and stream sessions support configurable retry behavior:
   ```
 
 - Stream append/read sessions created from `S2.basin(...).stream(...)` inherit this retry configuration.
-- The `appendRetryPolicy` dictates how failed appends should be retried. If you are not using a concurrency control like `match_seq_num`, then retrying a failed append could result in duplicate data, depending on the nature of the failure. This policy can be set to tolerate potential duplicates by retrying all failures (`"all"`) or only failures guaranteed not to have had a side effect (`"noSideEffects"`). In most cases, `"noSideEffects"` is the safer default unless you have explicit deduplication downstream.
+- The `appendRetryPolicy` dictates how failed appends should be retried. If you are not using a concurrency control like `match_seq_num`, then retrying a failed append could result in duplicate data, depending on the nature of the failure. This policy can be set to tolerate potential duplicates by retrying all failures (`"all"`, the default) or only failures guaranteed not to have had a side effect (`"noSideEffects"`). If you cannot tolerate potential duplicates and do not have explicit deduplication downstream, consider using `"noSideEffects"` instead of the default.
 
 See the generated API docs for the full description of `RetryConfig`, `AppendRetryPolicy` and `AppendSessionOptions`.
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,7 @@
 /**
  * Policy for retrying append operations.
  *
- * - `all`: Retry all append operations, including those that may have side effects
+ * - `all`: Retry all append operations, including those that may have side effects (default)
  * - `noSideEffects`: Only retry append operations that are guaranteed to have no side effects
  */
 export type AppendRetryPolicy = "all" | "noSideEffects";
@@ -26,7 +26,7 @@ export type RetryConfig = {
 
 	/**
 	 * Policy for retrying append operations.
-	 * @default "noSideEffects"
+	 * @default "all"
 	 */
 	appendRetryPolicy?: AppendRetryPolicy;
 

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -36,7 +36,7 @@ export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> & {
 } = {
 	maxAttempts: 3,
 	retryBackoffDurationMillis: 100,
-	appendRetryPolicy: "noSideEffects",
+	appendRetryPolicy: "all",
 	requestTimeoutMillis: 5000, // 5 seconds
 };
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -116,7 +116,7 @@ export class S2Stream {
 				);
 			},
 			(config, error) => {
-				if ((config.appendRetryPolicy ?? "noSideEffects") === "noSideEffects") {
+				if ((config.appendRetryPolicy ?? "all") === "noSideEffects") {
 					// Allow retry only when the append is naturally idempotent by containing
 					// a match_seq_num condition.
 					return !!args?.match_seq_num;

--- a/src/tests/retry.test.ts
+++ b/src/tests/retry.test.ts
@@ -93,7 +93,7 @@ describe("Retry Logic", () => {
 		it("should have correct default values", () => {
 			expect(DEFAULT_RETRY_CONFIG.maxAttempts).toBe(3);
 			expect(DEFAULT_RETRY_CONFIG.retryBackoffDurationMillis).toBe(100);
-			expect(DEFAULT_RETRY_CONFIG.appendRetryPolicy).toBe("noSideEffects");
+			expect(DEFAULT_RETRY_CONFIG.appendRetryPolicy).toBe("all");
 		});
 	});
 });


### PR DESCRIPTION
For consistency with rust sdk: https://github.com/s2-streamstore/s2-sdk-rust/blob/b9b2c93362bbb0005e9140c2fa8793a3f255f827/src/client.rs#L266