### PR TITLE
fix: mixed binary/string batches fail on fetch transport

### DIFF
--- a/.changeset/wet-lemons-juggle.md
+++ b/.changeset/wet-lemons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": minor
+---
+
+Fixes bug around base64 encoding of binary append records when batches include mixed string/byte records

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .claude
 
 # local examples
-examples/local
+packages/**/examples/local

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -573,17 +573,18 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 				body: record.body,
 			} as ReadRecord<Format>;
 		} else {
-			// Convert to string format
+			// Convert to string format with object headers
+			const headerEntries = record.headers?.map(
+				(h) =>
+					[
+						h.name ? textDecoder.decode(h.name) : "",
+						h.value ? textDecoder.decode(h.value) : "",
+					] as [string, string],
+			);
 			return {
 				seq_num: Number(record.seqNum),
 				timestamp: Number(record.timestamp),
-				headers: record.headers?.map(
-					(h) =>
-						[
-							h.name ? textDecoder.decode(h.name) : "",
-							h.value ? textDecoder.decode(h.value) : "",
-						] as [string, string],
-				),
+				headers: headerEntries ? Object.fromEntries(headerEntries) : undefined,
 				body: record.body ? textDecoder.decode(record.body) : undefined,
 			} as ReadRecord<Format>;
 		}

--- a/packages/streamstore/src/lib/stream/types.ts
+++ b/packages/streamstore/src/lib/stream/types.ts
@@ -20,7 +20,7 @@ export type ReadBatch<Format extends "string" | "bytes" = "string"> = Omit<
 	GeneratedReadBatch,
 	"records"
 > & {
-	records?: Array<ReadRecord<Format>>;
+	records: Array<ReadRecord<Format>>;
 };
 
 export type ReadRecord<Format extends "string" | "bytes" = "string"> = Omit<

--- a/packages/streamstore/src/tests/formats.e2e.test.ts
+++ b/packages/streamstore/src/tests/formats.e2e.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { AppendRecord, S2 } from "../index.js";
+import type { SessionTransports } from "../lib/stream/types.js";
+
+const transports: SessionTransports[] = ["fetch", "s2s"];
+const hasEnv = !!process.env.S2_ACCESS_TOKEN && !!process.env.S2_BASIN;
+const describeIf = hasEnv ? describe : describe.skip;
+
+describeIf("Mixed format integration tests", () => {
+	let s2: S2;
+	let basinName: string;
+	const createdStreams: string[] = [];
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
+
+	const bytesHeader = (label: string): [Uint8Array, Uint8Array] => [
+		encoder.encode("x-test-format"),
+		encoder.encode(label),
+	];
+
+	const decodeHeaderValue = (
+		headers: Array<[Uint8Array, Uint8Array]> | undefined,
+		name: string,
+	): string | undefined => {
+		if (!headers) return undefined;
+		for (const [rawName, rawValue] of headers) {
+			if (decoder.decode(rawName) === name) {
+				return decoder.decode(rawValue);
+			}
+		}
+		return undefined;
+	};
+
+	beforeAll(() => {
+		const token = process.env.S2_ACCESS_TOKEN;
+		const basin = process.env.S2_BASIN;
+		if (!token || !basin) return;
+		s2 = new S2({ accessToken: token });
+		basinName = basin;
+	});
+
+	afterAll(async () => {
+		if (!s2 || !basinName) {
+			return;
+		}
+		const basin = s2.basin(basinName);
+		for (const streamName of createdStreams) {
+			try {
+				await basin.streams.delete({ stream: streamName });
+			} catch (error) {
+				console.warn("Failed to cleanup test stream:", streamName, error);
+			}
+		}
+	});
+
+	it.each(transports)(
+		"supports mixed string/bytes across unary and session APIs (%s)",
+		async (transport) => {
+			const basin = s2.basin(basinName);
+			const streamName = `integration-formats-${transport}-${crypto.randomUUID()}`;
+			await basin.streams.create({ stream: streamName });
+			createdStreams.push(streamName);
+			const stream = basin.stream(streamName, { forceTransport: transport });
+
+			// Append a mixed batch via unary append
+			const unaryRecords = [
+				AppendRecord.make("unary-string", {
+					"x-test-format": "string-unary",
+				}),
+				AppendRecord.make(encoder.encode("unary-bytes"), [
+					bytesHeader("bytes-unary"),
+				]),
+			];
+			await stream.append(unaryRecords);
+
+			// Append another mixed batch via append session
+			const sessionRecords = [
+				AppendRecord.make("session-string", {
+					"x-test-format": "string-session",
+				}),
+				AppendRecord.make(encoder.encode("session-bytes"), [
+					bytesHeader("bytes-session"),
+				]),
+			];
+			const session = await stream.appendSession();
+			await session.submit(sessionRecords);
+			await session.close();
+
+			// Unary read as strings
+			const readAsString = await stream.read({ seq_num: 0, count: 10 });
+			expect(readAsString.records.length).toBe(4);
+			const stringRecords = readAsString.records.filter((record) =>
+				record.headers?.["x-test-format"]?.startsWith("string"),
+			);
+			expect(stringRecords.map((record) => record.body)).toEqual(
+				expect.arrayContaining(["unary-string", "session-string"]),
+			);
+
+			// Unary read as bytes
+			const readAsBytes = await stream.read({
+				seq_num: 0,
+				count: 10,
+				as: "bytes",
+			});
+			expect(readAsBytes.records.length).toBe(4);
+			const unaryBytesMap = new Map<string, string>();
+			for (const record of readAsBytes.records) {
+				const label = decodeHeaderValue(record.headers, "x-test-format");
+				if (label && record.body) {
+					unaryBytesMap.set(label, decoder.decode(record.body));
+				}
+			}
+			expect(unaryBytesMap.get("string-unary")).toBe("unary-string");
+			expect(unaryBytesMap.get("bytes-unary")).toBe("unary-bytes");
+			expect(unaryBytesMap.get("string-session")).toBe("session-string");
+			expect(unaryBytesMap.get("bytes-session")).toBe("session-bytes");
+
+			// Streaming read session (strings)
+			const readSessionStrings = await stream.readSession({
+				seq_num: 0,
+				count: 4,
+			});
+			const sessionStringMap = new Map<string, string>();
+			let seen = 0;
+			for await (const record of readSessionStrings) {
+				const label = record.headers?.["x-test-format"];
+				if (label?.startsWith("string") && record.body) {
+					sessionStringMap.set(label, record.body);
+				}
+				seen += 1;
+				if (seen >= 4) {
+					break;
+				}
+			}
+			await readSessionStrings.cancel();
+			expect(sessionStringMap.get("string-unary")).toBe("unary-string");
+			expect(sessionStringMap.get("string-session")).toBe("session-string");
+
+			// Streaming read session (bytes)
+			const readSessionBytes = await stream.readSession({
+				seq_num: 0,
+				count: 4,
+				as: "bytes",
+			});
+			const sessionBytesMap = new Map<string, string>();
+			let bytesSeen = 0;
+			for await (const record of readSessionBytes) {
+				const label = decodeHeaderValue(record.headers, "x-test-format");
+				if (label && record.body) {
+					sessionBytesMap.set(label, decoder.decode(record.body));
+				}
+				bytesSeen += 1;
+				if (bytesSeen >= 4) {
+					break;
+				}
+			}
+			await readSessionBytes.cancel();
+			expect(sessionBytesMap.get("string-unary")).toBe("unary-string");
+			expect(sessionBytesMap.get("bytes-unary")).toBe("unary-bytes");
+			expect(sessionBytesMap.get("string-session")).toBe("session-string");
+			expect(sessionBytesMap.get("bytes-session")).toBe("session-bytes");
+		},
+	);
+});

--- a/packages/streamstore/tsconfig.build.cjs.json
+++ b/packages/streamstore/tsconfig.build.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "rootDir": "src",
     "module": "CommonJS",
     "moduleResolution": "node10",
     "verbatimModuleSyntax": false,

--- a/packages/streamstore/tsconfig.build.esm.json
+++ b/packages/streamstore/tsconfig.build.esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/esm",
+    "rootDir": "src",
     "module": "NodeNext",
     "moduleResolution": "node16",
     "noUncheckedIndexedAccess": false

--- a/packages/streamstore/tsconfig.json
+++ b/packages/streamstore/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node16",
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
+    "rootDir": ".",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
@@ -24,5 +25,6 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
+  "include": ["src/**/*", "examples/**/*"],
   "exclude": ["src/generated", "dist"]
 }


### PR DESCRIPTION
Thanks to @willmruzek for the bug report.

- adjusts check for determining if a batch needs base64 encoding (if any record uses bytes, the entire batch needs to be sent as base64)
- adds also an e2e test around this
- `ReadBatch` now has a required `records` field

(Planning to drop base64 encoding in favor of [protobuf](https://s2.dev/docs/rest/records/overview#protobuf-messages) bodies as follow up.)