### PR TITLE
fix: fetch read session timer + fail fast on connection error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .claude
 
 # local examples
-packages/**/examples/local
+packages/*/examples/local/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -3529,7 +3529,7 @@
     },
     "packages/patterns": {
       "name": "@s2-dev/streamstore-patterns",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "^3.3.11"
@@ -3542,12 +3542,12 @@
         "tsx": "^4.19.2"
       },
       "peerDependencies": {
-        "@s2-dev/streamstore": ">=0.18.1"
+        "@s2-dev/streamstore": ">=0.19.0"
       }
     },
     "packages/streamstore": {
       "name": "@s2-dev/streamstore",
-      "version": "0.18.1",
+      "version": "0.19.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",

--- a/packages/streamstore/examples/local/read-session.ts
+++ b/packages/streamstore/examples/local/read-session.ts
@@ -1,9 +1,0 @@
-import { AppendRecord, BatchTransform, S2 } from "../../src/index.js";
-
-const s2 = new S2({
-	accessToken: process.env.S2_ACCESS_TOKEN!,
-});
-
-const basin = s2.basin("demo-10202025").stream("frame-stream-0007");
-
-const sesh = await basin.readSession({ seq_num: 0 });

--- a/packages/streamstore/src/lib/event-stream.ts
+++ b/packages/streamstore/src/lib/event-stream.ts
@@ -85,7 +85,14 @@ export class EventStream<T>
 	// Polyfill for older browsers
 	[Symbol.asyncIterator](): AsyncIterableIterator<T> {
 		const fn = (ReadableStream.prototype as any)[Symbol.asyncIterator];
-		if (typeof fn === "function") return fn.call(this);
+		if (typeof fn === "function") {
+			try {
+				return fn.call(this);
+			} catch {
+				// Native method may throw "Illegal invocation" when called on subclass
+				// Fall through to manual implementation
+			}
+		}
 		const reader = this.getReader();
 		return {
 			next: async () => {

--- a/packages/streamstore/src/lib/event-stream.ts
+++ b/packages/streamstore/src/lib/event-stream.ts
@@ -2,6 +2,10 @@
  * Code from Speakeasy (https://speakeasy.com).
  */
 
+import createDebug from "debug";
+
+const debug = createDebug("s2:event-stream");
+
 export type SseMessage<T> = {
 	data?: T | undefined;
 	event?: string | undefined;
@@ -36,10 +40,12 @@ export class EventStream<T>
 	) {
 		const upstream = responseBody.getReader();
 		let buffer: Uint8Array = new Uint8Array();
+		const eventStreamId = Math.random().toString(36).slice(2);
 		super({
 			async pull(downstream) {
 				try {
 					while (true) {
+						debug("pull loop, eventstream=%s", eventStreamId);
 						const match = findBoundary(buffer);
 						if (!match) {
 							const chunk = await upstream.read();


### PR DESCRIPTION
- Re-works prior (reverted) fix for read session liveness timer, for fetch transport only
- Handle connection failures from session connection eagerly in the retrying read session