### PR TITLE
examples: tailing read additional context

### DIFF
--- a/examples/tailing-read.ts
+++ b/examples/tailing-read.ts
@@ -42,7 +42,7 @@ const appendSession = await streamClient.appendSession({
 const readAbort = new AbortController();
 const readSession = await streamClient.readSession(
 	{
-		start: { from: { tailOffset: 0 }, clamp: true },
+		start: { from: { seqNum: 0 }, clamp: true },
 	},
 	{ signal: readAbort.signal },
 );
@@ -69,6 +69,7 @@ const readLoop = async () => {
 	try {
 		for await (const record of readSession) {
 			console.log("tailing read:", record.seqNum, record.body);
+			console.log("last observed tail: %s, next read position %s", readSession.lastObservedTail(), readSession.nextReadPosition())
 		}
 	} catch (error: unknown) {
 		if (


### PR DESCRIPTION
Not for merge (in current form).

I ran the `examples/tailing-read.ts` example a few times. This will use the same stream (a new one created in the provided `S2_BASIN`).  The example was modified to always start reads from the head of the stream, and to print the last observed tail (and next read position, for manual resumption).

This prints the output from the last time I ran it. Note the switch from `undefined` to a `StreamPosition` at tail `..16`. Prior to this, all reads were from tiered state, and no information about the live tail was returned. Once we transition to recent reads, S2 starts communicating tail information, which becomes accessible via `lastObservedTail()` on the session.

```console
sb@bandar-mac s2-sdk-typescript % S2_ACCESS_TOKEN=my-token S2_BASIN=my-basin npx tsx examples/tailing-read.ts
append ack (..16):
tailing read: 0 periodic-0
last observed tail: undefined, next read position { seqNum: 2, timestamp: 2026-01-19T21:12:09.053Z }
tailing read: 1 periodic-1
last observed tail: undefined, next read position { seqNum: 3, timestamp: 2026-01-19T21:12:11.129Z }
tailing read: 2 periodic-2
last observed tail: undefined, next read position { seqNum: 5, timestamp: 2026-01-19T21:12:15.280Z }
tailing read: 3 periodic-3
last observed tail: undefined, next read position { seqNum: 5, timestamp: 2026-01-19T21:12:15.280Z }
tailing read: 4 periodic-4
last observed tail: undefined, next read position { seqNum: 5, timestamp: 2026-01-19T21:12:15.280Z }
tailing read: 5 periodic-0
last observed tail: undefined, next read position { seqNum: 6, timestamp: 2026-01-19T21:13:20.534Z }
tailing read: 6 periodic-1
last observed tail: undefined, next read position { seqNum: 7, timestamp: 2026-01-19T21:13:22.779Z }
tailing read: 7 periodic-2
last observed tail: undefined, next read position { seqNum: 8, timestamp: 2026-01-19T21:13:24.853Z }
tailing read: 8 periodic-3
last observed tail: undefined, next read position { seqNum: 9, timestamp: 2026-01-19T21:13:26.948Z }
tailing read: 9 periodic-4
last observed tail: undefined, next read position { seqNum: 10, timestamp: 2026-01-19T21:13:29.027Z }
tailing read: 10 periodic-0
last observed tail: undefined, next read position { seqNum: 11, timestamp: 2026-01-19T21:15:16.995Z }
tailing read: 11 periodic-1
last observed tail: undefined, next read position { seqNum: 12, timestamp: 2026-01-19T21:15:19.231Z }
tailing read: 12 periodic-2
last observed tail: undefined, next read position { seqNum: 13, timestamp: 2026-01-19T21:15:21.326Z }
tailing read: 13 periodic-3
last observed tail: undefined, next read position { seqNum: 14, timestamp: 2026-01-19T21:15:23.404Z }
tailing read: 14 periodic-4
last observed tail: undefined, next read position { seqNum: 15, timestamp: 2026-01-19T21:15:25.499Z }
tailing read: 15 periodic-0
last observed tail: { seqNum: 16, timestamp: 2026-01-19T21:15:52.163Z }, next read position { seqNum: 16, timestamp: 2026-01-19T21:15:52.163Z }
append ack (..17):
tailing read: 16 periodic-1
last observed tail: { seqNum: 17, timestamp: 2026-01-19T21:15:54.404Z }, next read position { seqNum: 17, timestamp: 2026-01-19T21:15:54.404Z }
append ack (..18):
tailing read: 17 periodic-2
last observed tail: { seqNum: 18, timestamp: 2026-01-19T21:15:56.481Z }, next read position { seqNum: 18, timestamp: 2026-01-19T21:15:56.481Z }
append ack (..19):
tailing read: 18 periodic-3
last observed tail: { seqNum: 19, timestamp: 2026-01-19T21:15:58.577Z }, next read position { seqNum: 19, timestamp: 2026-01-19T21:15:58.577Z }
append ack (..20):
tailing read: 19 periodic-4
last observed tail: { seqNum: 20, timestamp: 2026-01-19T21:16:00.675Z }, next read position { seqNum: 20, timestamp: 2026-01-19T21:16:00.675Z }
Finished appending. Allowing read session to drain.
```