### PR TITLE
feat: examples docs + config and paginator tweaks

### DIFF
--- a/.changeset/curvy-kiwis-leave.md
+++ b/.changeset/curvy-kiwis-leave.md
@@ -5,3 +5,4 @@
   - Deprecate timeout settings under retry config (backwards-compatible)
   - Reduce default connection timeout from 5s to 3s
   - Change basins.listAll() and streams.listAll() to accept includeDeleted in options object instead of as first positional argument
+  - Rename delay config options to clarify they apply to base delay

--- a/.changeset/curvy-kiwis-leave.md
+++ b/.changeset/curvy-kiwis-leave.md
@@ -1,0 +1,7 @@
+---
+"@s2-dev/streamstore": patch
+---
+  - Promote connectionTimeoutMillis and requestTimeoutMillis to top-level client options
+  - Deprecate timeout settings under retry config (backwards-compatible)
+  - Reduce default connection timeout from 5s to 3s
+  - Change basins.listAll() and streams.listAll() to accept includeDeleted in options object instead of as first positional argument

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ const s2 = new S2({
 	accessToken,
 	retry: {
 		maxAttempts: 3,
-		minDelayMillis: 100,
-		maxDelayMillis: 500,
+		minBaseDelayMillis: 100,
+		maxBaseDelayMillis: 500,
 		appendRetryPolicy: "all",
 		requestTimeoutMillis: 5_000,
 	},

--- a/examples/client-config.ts
+++ b/examples/client-config.ts
@@ -18,8 +18,8 @@ const s2 = new S2({
 	accessToken,
 	retry: {
 		maxAttempts: 3,
-		minDelayMillis: 100,
-		maxDelayMillis: 500,
+		minBaseDelayMillis: 100,
+		maxBaseDelayMillis: 500,
 		appendRetryPolicy: "all",
 		requestTimeoutMillis: 5_000,
 	},

--- a/examples/docs/account-and-basins.ts
+++ b/examples/docs/account-and-basins.ts
@@ -157,3 +157,14 @@ function accessTokenAutoPrefix() {
 void accessTokenReadOnly;
 void accessTokenGranular;
 void accessTokenAutoPrefix;
+
+// Pagination example - not executed by default
+async function paginationExample() {
+	// ANCHOR: pagination
+	// Iterate through all streams with automatic pagination
+	for await (const stream of basin.streams.listAll()) {
+		console.log(stream.name);
+	}
+	// ANCHOR_END: pagination
+}
+void paginationExample;

--- a/examples/docs/account-and-basins.ts
+++ b/examples/docs/account-and-basins.ts
@@ -1,0 +1,159 @@
+/**
+ * Documentation examples for Account and Basins page.
+ * These snippets are extracted by the docs build script.
+ *
+ * Run with: npx tsx examples/docs/account-and-basins.ts
+ * Requires: S2_ACCESS_TOKEN, S2_BASIN environment variables
+ *
+ * Note: These examples create resources with hardcoded names.
+ * They may fail on repeated runs if resources already exist.
+ */
+
+import { S2, S2Environment } from "@s2-dev/streamstore";
+
+const accessToken = process.env.S2_ACCESS_TOKEN;
+if (!accessToken) {
+	throw new Error("S2_ACCESS_TOKEN is required");
+}
+
+const client = new S2({
+	...S2Environment.parse(),
+	accessToken,
+});
+
+const basinName = process.env.S2_BASIN;
+if (!basinName) {
+	throw new Error("S2_BASIN is required");
+}
+
+// ANCHOR: basin-operations
+// List basins
+const basins = await client.basins.list();
+
+// Create a basin
+await client.basins.create({ basin: "my-events" });
+
+// Get configuration
+const config = await client.basins.getConfig({ basin: "my-events" });
+
+// Delete
+await client.basins.delete({ basin: "my-events" });
+// ANCHOR_END: basin-operations
+console.log(`Basins: ${basins.basins.length} found, config:`, config);
+
+const basin = client.basin(basinName);
+
+// ANCHOR: stream-operations
+// List streams
+const streams = await basin.streams.list({ prefix: "user-" });
+
+// Create a stream
+await basin.streams.create({
+	stream: "user-actions",
+	config: {
+		/* optional configuration */
+	},
+});
+
+// Get configuration
+const streamConfig = await basin.streams.getConfig({ stream: "user-actions" });
+
+// Delete
+await basin.streams.delete({ stream: "user-actions" });
+// ANCHOR_END: stream-operations
+console.log(`Streams: ${streams.streams.length} found, config:`, streamConfig);
+
+// ANCHOR: access-token-basic
+// List tokens (returns metadata, not the secret)
+const tokens = await client.accessTokens.list();
+
+// Issue a token scoped to streams under "users/1234/"
+const { accessToken: issuedToken } = await client.accessTokens.issue({
+	id: "user-1234-rw-token",
+	scope: {
+		basins: { prefix: "" }, // all basins
+		streams: { prefix: "users/1234/" },
+		opGroups: { stream: { read: true, write: true } },
+	},
+	expiresAt: new Date("2027-01-01"),
+});
+
+// Revoke a token
+await client.accessTokens.revoke({ id: "user-1234-rw-token" });
+// ANCHOR_END: access-token-basic
+console.log(`Tokens: ${tokens.accessTokens.length} found, issued: ${issuedToken ? "yes" : "no"}`);
+
+// ANCHOR: access-token-restricted
+await client.accessTokens.issue({
+	id: "restricted-token",
+	scope: {
+		basins: { exact: "production" }, // Only the "production" basin
+		streams: { prefix: "logs/" }, // Only streams starting with "logs/"
+		opGroups: { stream: { read: true } },
+	},
+});
+// ANCHOR_END: access-token-restricted
+
+console.log("Account and basins examples completed");
+
+// The following are additional documentation snippets that are not executed.
+// They would create tokens that aren't cleaned up.
+
+function accessTokenReadOnly() {
+	// ANCHOR: access-token-read-only
+	client.accessTokens.issue({
+		id: "consumer-token",
+		scope: {
+			opGroups: {
+				stream: { read: true },
+			},
+		},
+	});
+	// ANCHOR_END: access-token-read-only
+}
+
+function accessTokenGranular() {
+	// ANCHOR: access-token-granular
+	client.accessTokens.issue({
+		id: "append-only-token",
+		scope: {
+			ops: ["append", "check-tail"],
+		},
+	});
+	// ANCHOR_END: access-token-granular
+}
+
+function accessTokenAutoPrefix() {
+	// ANCHOR: access-token-auto-prefix
+	// Issue a tenant-scoped token
+	const tenantToken = client.accessTokens.issue({
+		id: "tenant-a-token",
+		scope: {
+			basins: { exact: "shared-basin" },
+			streams: { prefix: "tenant-a/" },
+			ops: ["append", "read", "create-stream", "list-streams"],
+		},
+		autoPrefixStreams: true,
+	});
+
+	// Tenant's code sees a flat namespace
+	// const tenantClient = new S2({ accessToken: tenantToken.accessToken });
+	// const basin = tenantClient.basin("shared-basin");
+
+	// Creates "tenant-a/orders" on the server
+	// await basin.streams.create({ stream: "orders" });
+
+	// Lists only streams in tenant-a/, but returns them without the prefix
+	// const streams = await basin.streams.list(); // ["orders", "events", ...]
+
+	// Appends to "tenant-a/orders" transparently
+	// await basin
+	// 	.stream("orders")
+	// 	.append(AppendInput.create([AppendRecord.string({ body: "event" })]));
+	// ANCHOR_END: access-token-auto-prefix
+	void tenantToken;
+}
+
+void accessTokenReadOnly;
+void accessTokenGranular;
+void accessTokenAutoPrefix;

--- a/examples/docs/configuration.ts
+++ b/examples/docs/configuration.ts
@@ -1,0 +1,54 @@
+/**
+ * Documentation examples for Configuration page.
+ * These snippets are extracted by the docs build script.
+ *
+ * Run with: npx tsx examples/docs/configuration.ts
+ * Requires: S2_ACCESS_TOKEN environment variable
+ */
+
+import { S2 } from "@s2-dev/streamstore";
+
+// Each snippet is wrapped in a block scope to allow independent `client` declarations
+{
+	// ANCHOR: custom-endpoints
+	const client = new S2({
+		accessToken: "local-token",
+		endpoints: {
+			account: "http://localhost:8080",
+			basin: "http://localhost:8080",
+		},
+	});
+	// ANCHOR_END: custom-endpoints
+	void client;
+}
+
+{
+	const token = process.env.S2_ACCESS_TOKEN!;
+	// ANCHOR: retry-config
+	const client = new S2({
+		accessToken: token,
+		retry: {
+			maxAttempts: 5,
+			minDelayMillis: 100,
+			maxDelayMillis: 2000,
+		},
+	});
+	// ANCHOR_END: retry-config
+	void client;
+}
+
+{
+	const token = process.env.S2_ACCESS_TOKEN!;
+	// ANCHOR: timeout-config
+	const client = new S2({
+		accessToken: token,
+		retry: {
+			connectionTimeoutMillis: 5000,
+			requestTimeoutMillis: 10000,
+		},
+	});
+	// ANCHOR_END: timeout-config
+	void client;
+}
+
+console.log("Configuration examples loaded");

--- a/examples/docs/configuration.ts
+++ b/examples/docs/configuration.ts
@@ -42,10 +42,8 @@ import { S2 } from "@s2-dev/streamstore";
 	// ANCHOR: timeout-config
 	const client = new S2({
 		accessToken: token,
-		retry: {
-			connectionTimeoutMillis: 5000,
-			requestTimeoutMillis: 10000,
-		},
+		connectionTimeoutMillis: 3000,
+		requestTimeoutMillis: 5000,
 	});
 	// ANCHOR_END: timeout-config
 	void client;

--- a/examples/docs/configuration.ts
+++ b/examples/docs/configuration.ts
@@ -29,8 +29,8 @@ import { S2 } from "@s2-dev/streamstore";
 		accessToken: token,
 		retry: {
 			maxAttempts: 5,
-			minDelayMillis: 100,
-			maxDelayMillis: 2000,
+			minBaseDelayMillis: 100,
+			maxBaseDelayMillis: 2000,
 		},
 	});
 	// ANCHOR_END: retry-config

--- a/examples/docs/overview.ts
+++ b/examples/docs/overview.ts
@@ -1,0 +1,22 @@
+/**
+ * Documentation examples for SDK Overview page.
+ * These snippets are extracted by the docs build script.
+ *
+ * Run with: npx tsx examples/docs/overview.ts
+ * Requires: S2_ACCESS_TOKEN, S2_BASIN environment variables
+ */
+
+// ANCHOR: create-client
+import { S2 } from "@s2-dev/streamstore";
+
+const client = new S2({
+	accessToken: process.env.S2_ACCESS_TOKEN!,
+});
+
+const basin = client.basin("my-basin");
+const stream = basin.stream("my-stream");
+// ANCHOR_END: create-client
+
+void stream;
+
+console.log("Client created successfully");

--- a/examples/docs/streams.ts
+++ b/examples/docs/streams.ts
@@ -1,0 +1,191 @@
+/**
+ * Documentation examples for Streams page.
+ * These snippets are extracted by the docs build script.
+ *
+ * Run with: npx tsx examples/docs/streams.ts
+ * Requires: S2_ACCESS_TOKEN, S2_BASIN environment variables
+ */
+
+import {
+	AppendInput,
+	AppendRecord,
+	BatchTransform,
+	Producer,
+	S2,
+	S2Environment,
+	S2Error,
+} from "@s2-dev/streamstore";
+
+const accessToken = process.env.S2_ACCESS_TOKEN;
+if (!accessToken) {
+	throw new Error("S2_ACCESS_TOKEN is required");
+}
+
+const basinName = process.env.S2_BASIN;
+if (!basinName) {
+	throw new Error("S2_BASIN is required");
+}
+
+const client = new S2({
+	...S2Environment.parse(),
+	accessToken,
+});
+
+const basin = client.basin(basinName);
+const streamName = `docs-streams-${Date.now()}`;
+
+// Ensure stream exists
+await basin.streams.create({ stream: streamName }).catch((e) => {
+	if (!(e instanceof S2Error && e.status === 409)) throw e;
+});
+
+
+// ANCHOR: simple-append
+const stream = basin.stream(streamName);
+const ack = await stream.append(
+	AppendInput.create([
+		AppendRecord.string({ body: "first event" }),
+		AppendRecord.string({ body: "second event" }),
+	]),
+);
+
+// ack tells us where the records landed
+console.log(`Wrote records ${ack.start.seqNum} through ${ack.end.seqNum - 1}`);
+// ANCHOR_END: simple-append
+
+// ANCHOR: simple-read
+const batch = await stream.read({
+	start: { from: { seqNum: 0 } },
+	stop: { limits: { count: 100 } },
+});
+
+for (const record of batch.records) {
+	console.log(`[${record.seqNum}] ${record.body}`);
+}
+// ANCHOR_END: simple-read
+
+async function appendSessionExample() {
+	// ANCHOR: append-session
+	const session = await stream.appendSession();
+
+	// Submit a batch - this enqueues it and returns a ticket
+	const ticket = await session.submit(
+		AppendInput.create([
+			AppendRecord.string({ body: "event-1" }),
+			AppendRecord.string({ body: "event-2" }),
+		]),
+	);
+
+	// The ticket resolves when the batch is durable
+	const ack = await ticket.ack();
+	console.log(`Durable at seqNum ${ack.start.seqNum}`);
+
+	await session.close();
+	// ANCHOR_END: append-session
+}
+
+async function producerExample() {
+	// ANCHOR: producer
+	const producer = new Producer(
+		new BatchTransform({ lingerDurationMillis: 5 }),
+		await stream.appendSession(),
+	);
+
+	// Submit individual records
+	const ticket = await producer.submit(
+		AppendRecord.string({ body: "my event" }),
+	);
+
+	// Get the exact sequence number for this record
+	const ack = await ticket.ack();
+	console.log(`Record durable at seqNum ${ack.seqNum()}`);
+
+	await producer.close();
+	// ANCHOR_END: producer
+}
+
+async function readSessionExample() {
+	// ANCHOR: read-session
+	const session = await stream.readSession({
+		start: { from: { seqNum: 0 } },
+	});
+
+	for await (const record of session) {
+		console.log(`[${record.seqNum}] ${record.body}`);
+	}
+	// ANCHOR_END: read-session
+}
+
+async function readSessionTailOffset() {
+	// ANCHOR: read-session-tail-offset
+	// Start reading from 10 records before the current tail
+	const session = await stream.readSession({
+		start: { from: { tailOffset: 10 } },
+	});
+
+	for await (const record of session) {
+		console.log(`[${record.seqNum}] ${record.body}`);
+	}
+	// ANCHOR_END: read-session-tail-offset
+}
+
+async function readSessionTimestamp() {
+	// ANCHOR: read-session-timestamp
+	// Start reading from a specific timestamp
+	const oneHourAgo = new Date(Date.now() - 3600 * 1000);
+	const session = await stream.readSession({
+		start: { from: { timestamp: oneHourAgo } },
+	});
+
+	for await (const record of session) {
+		console.log(`[${record.seqNum}] ${record.body}`);
+	}
+	// ANCHOR_END: read-session-timestamp
+}
+
+async function readSessionUntil() {
+	// ANCHOR: read-session-until
+	// Read records until a specific timestamp
+	const oneHourAgo = new Date(Date.now() - 3600 * 1000);
+	const session = await stream.readSession({
+		start: { from: { seqNum: 0 } },
+		stop: { untilTimestamp: oneHourAgo },
+	});
+
+	for await (const record of session) {
+		console.log(`[${record.seqNum}] ${record.body}`);
+	}
+	// ANCHOR_END: read-session-until
+}
+
+async function readSessionWait() {
+	// ANCHOR: read-session-wait
+	// Read all available records, and once reaching the current tail, wait an additional 30 seconds for new ones
+	const session = await stream.readSession({
+		start: { from: { seqNum: 0 } },
+		stop: { waitSecs: 30 },
+	});
+
+	for await (const record of session) {
+		console.log(`[${record.seqNum}] ${record.body}`);
+	}
+	// ANCHOR_END: read-session-wait
+}
+
+async function checkTailExample() {
+	// ANCHOR: check-tail
+	const { tail } = await stream.checkTail();
+	console.log(`Stream has ${tail.seqNum} records`);
+	// ANCHOR_END: check-tail
+}
+
+// Run examples
+await appendSessionExample();
+await producerExample();
+await checkTailExample();
+
+// Cleanup
+await basin.streams.delete({ stream: streamName });
+await stream.close();
+
+console.log("Streams examples completed");

--- a/examples/image.ts
+++ b/examples/image.ts
@@ -51,8 +51,8 @@ const s2 = new S2({
 	accessToken,
 	retry: {
 		maxAttempts: 3,
-		minDelayMillis: 100,
-		maxDelayMillis: 1000,
+		minBaseDelayMillis: 100,
+		maxBaseDelayMillis: 1000,
 		appendRetryPolicy: "noSideEffects",
 	},
 });

--- a/examples/patterns-serialization.ts
+++ b/examples/patterns-serialization.ts
@@ -25,7 +25,7 @@ const s2 = new S2({
 	accessToken,
 	retry: {
 		maxAttempts: 10,
-		minDelayMillis: 100,
+		minBaseDelayMillis: 100,
 		appendRetryPolicy: "all",
 	},
 });

--- a/packages/streamstore/src/basin.ts
+++ b/packages/streamstore/src/basin.ts
@@ -39,6 +39,8 @@ export class S2Basin {
 			baseUrl: options.baseUrl,
 			accessToken: options.accessToken,
 			basinName: options.includeBasinHeader ? name : undefined,
+			connectionTimeoutMillis: options.retryConfig?.connectionTimeoutMillis,
+			requestTimeoutMillis: options.retryConfig?.requestTimeoutMillis,
 			retry: options.retryConfig,
 		};
 		const headers: Record<string, string> = {};

--- a/packages/streamstore/src/basins.ts
+++ b/packages/streamstore/src/basins.ts
@@ -124,21 +124,20 @@ export class S2Basins {
 	 * List all basins with automatic pagination.
 	 * Returns a lazy async iterable that fetches pages as needed.
 	 *
-	 * @param includeDeleted - Include basins that are being deleted (default: false)
-	 * @param args - Optional filtering options: `prefix` to filter by name prefix, `limit` for max results per page
+	 * @param args - Optional options: `prefix` to filter by name prefix, `limit` for max results per page, `includeDeleted` to include basins pending deletion
 	 *
 	 * @example
 	 * ```ts
-	 * for await (const basin of s2.basins.listAll(false, { prefix: "my-" })) {
+	 * for await (const basin of s2.basins.listAll({ prefix: "my-" })) {
 	 *   console.log(basin.name);
 	 * }
 	 * ```
 	 */
 	public listAll(
-		includeDeleted = false,
 		args?: Types.ListAllBasinsInput,
 		options?: S2RequestOptions,
 	): AsyncIterable<Types.BasinInfo> {
+		const { includeDeleted, ...listArgs } = args ?? {};
 		return paginate(
 			(a) =>
 				this.list(a, options).then((r) => ({
@@ -147,7 +146,7 @@ export class S2Basins {
 					),
 					hasMore: r.hasMore,
 				})),
-			args ?? {},
+			listArgs,
 			(basin) => basin.name,
 		);
 	}

--- a/packages/streamstore/src/common.ts
+++ b/packages/streamstore/src/common.ts
@@ -21,18 +21,18 @@ export type RetryConfig = {
 
 	/**
 	 * Minimum delay in milliseconds for exponential backoff.
-	 * The first retry will have a delay in the range [minDelayMillis, 2*minDelayMillis).
+	 * The first retry will have a delay in the range [minBaseDelayMillis, 2*minBaseDelayMillis).
 	 * @default 100
 	 */
-	minDelayMillis?: number;
+	minBaseDelayMillis?: number;
 
 	/**
 	 * Maximum base delay in milliseconds for exponential backoff.
 	 * Once the exponential backoff reaches this value, it stays capped here.
-	 * Note: actual delay with jitter can be up to 2*maxDelayMillis.
+	 * Note: actual delay with jitter can be up to 2*maxBaseDelayMillis.
 	 * @default 1000
 	 */
-	maxDelayMillis?: number;
+	maxBaseDelayMillis?: number;
 
 	/**
 	 * Policy for retrying append operations.
@@ -127,7 +127,7 @@ export type S2ClientOptions = {
 	/**
 	 * Retry configuration for handling transient failures.
 	 * Applies to management operations (basins, streams, tokens) and stream operations (read, append).
-	 * @default { maxAttempts: 3, minDelayMillis: 100, maxDelayMillis: 1000, appendRetryPolicy: "all" }
+	 * @default { maxAttempts: 3, minBaseDelayMillis: 100, maxBaseDelayMillis: 1000, appendRetryPolicy: "all" }
 	 */
 	retry?: RetryConfig;
 };

--- a/packages/streamstore/src/common.ts
+++ b/packages/streamstore/src/common.ts
@@ -45,6 +45,8 @@ export type RetryConfig = {
 	 * the attempt timed out and applying retry logic.
 	 *
 	 * Used by retrying append sessions. When unset, defaults to 5000ms.
+	 *
+	 * @deprecated Use `requestTimeoutMillis` on {@link S2ClientOptions} instead.
 	 */
 	requestTimeoutMillis?: number;
 
@@ -56,7 +58,8 @@ export type RetryConfig = {
 	 * Only applies to S2S (HTTP/2) transport when establishing new connections.
 	 * Reused pooled connections are not subject to this timeout.
 	 *
-	 * @default 5000
+	 * @default 3000
+	 * @deprecated Use `connectionTimeoutMillis` on {@link S2ClientOptions} instead.
 	 */
 	connectionTimeoutMillis?: number;
 };
@@ -103,6 +106,24 @@ export type S2ClientOptions = {
 	 * Defaults to AWS (`aws.s2.dev` and `{basin}.b.aws.s2.dev`) with the API base path inferred as `/v1`.
 	 */
 	endpoints?: S2Endpoints | S2EndpointsInit;
+	/**
+	 * Maximum time in milliseconds to wait for an append ack before considering
+	 * the attempt timed out and applying retry logic.
+	 *
+	 * Used by retrying append sessions. When unset, defaults to 5000ms.
+	 */
+	requestTimeoutMillis?: number;
+	/**
+	 * Maximum time in milliseconds to wait for connection establishment.
+	 * This is a "fail fast" timeout that aborts slow connections early.
+	 * Connection time counts toward requestTimeoutMillis.
+	 *
+	 * Only applies to S2S (HTTP/2) transport when establishing new connections.
+	 * Reused pooled connections are not subject to this timeout.
+	 *
+	 * @default 3000
+	 */
+	connectionTimeoutMillis?: number;
 	/**
 	 * Retry configuration for handling transient failures.
 	 * Applies to management operations (basins, streams, tokens) and stream operations (read, append).

--- a/packages/streamstore/src/lib/paginate.ts
+++ b/packages/streamstore/src/lib/paginate.ts
@@ -31,8 +31,12 @@ export type PageFetcher<TItem, TArgs> = (
 /**
  * Arguments for listAll pagination methods.
  * Omits startAfter since pagination is handled automatically.
+ * Adds includeDeleted option to include resources pending deletion.
  */
-export type ListAllArgs<TArgs> = Omit<TArgs, "startAfter">;
+export type ListAllArgs<TArgs> = Omit<TArgs, "startAfter"> & {
+	/** Include resources that are pending deletion (default: false). */
+	includeDeleted?: boolean;
+};
 
 /**
  * Creates a lazy async iterable that automatically paginates through all results.

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -94,7 +94,7 @@ export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
 	maxDelayMillis: 1000,
 	appendRetryPolicy: "all",
 	requestTimeoutMillis: 5000, // 5 seconds
-	connectionTimeoutMillis: 5000, // 5 seconds
+	connectionTimeoutMillis: 3000, // 3 seconds
 };
 
 const RETRYABLE_STATUS_CODES = new Set([

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -90,8 +90,8 @@ function toSDKReadRecord<Format extends "string" | "bytes">(
  */
 export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
 	maxAttempts: 3,
-	minDelayMillis: 100,
-	maxDelayMillis: 1000,
+	minBaseDelayMillis: 100,
+	maxBaseDelayMillis: 1000,
 	appendRetryPolicy: "all",
 	requestTimeoutMillis: 5000, // 5 seconds
 	connectionTimeoutMillis: 3000, // 3 seconds
@@ -131,23 +131,23 @@ export function isRetryable(error: S2Error): boolean {
  * with additive jitter.
  *
  * Formula:
- *   baseDelay = min(minDelayMillis * 2^attempt, maxDelayMillis)
+ *   baseDelay = min(minBaseDelayMillis * 2^attempt, maxBaseDelayMillis)
  *   jitter = random(0, baseDelay)
  *   delay = baseDelay + jitter
  *
  * @param attempt - Zero-based retry attempt number (0 = first retry)
- * @param minDelayMillis - Minimum delay for exponential backoff
- * @param maxDelayMillis - Maximum base delay (actual delay can be up to 2x with jitter)
+ * @param minBaseDelayMillis - Minimum delay for exponential backoff
+ * @param maxBaseDelayMillis - Maximum base delay (actual delay can be up to 2x with jitter)
  */
 export function calculateDelay(
 	attempt: number,
-	minDelayMillis: number,
-	maxDelayMillis: number,
+	minBaseDelayMillis: number,
+	maxBaseDelayMillis: number,
 ): number {
 	// Calculate exponential backoff: minDelay * 2^attempt, capped at maxDelay
 	const baseDelay = Math.min(
-		minDelayMillis * Math.pow(2, attempt),
-		maxDelayMillis,
+		minBaseDelayMillis * Math.pow(2, attempt),
+		maxBaseDelayMillis,
 	);
 
 	// Add jitter: random value in [0, baseDelay)
@@ -220,8 +220,8 @@ export async function withRetries<T>(
 			// Calculate delay and wait before retrying
 			const delay = calculateDelay(
 				attemptNo - 1,
-				config.minDelayMillis,
-				config.maxDelayMillis,
+				config.minBaseDelayMillis,
+				config.maxBaseDelayMillis,
 			);
 			debugWith(
 				"retryable error, backing off for %dms, status=%s",
@@ -275,8 +275,8 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 				if (isRetryable(error) && attempt < effectiveMax - 1) {
 					const delay = calculateDelay(
 						attempt,
-						retryConfig.minDelayMillis,
-						retryConfig.maxDelayMillis,
+						retryConfig.minBaseDelayMillis,
+						retryConfig.maxBaseDelayMillis,
 					);
 					debugRead(
 						"connection error in create, will retry after %dms, status=%s",
@@ -334,8 +334,8 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 							if (isRetryable(error) && attempt < effectiveMax - 1) {
 								const delay = calculateDelay(
 									attempt,
-									retryConfig.minDelayMillis,
-									retryConfig.maxDelayMillis,
+									retryConfig.minBaseDelayMillis,
+									retryConfig.maxBaseDelayMillis,
 								);
 								debugRead(
 									"connection error, will retry after %dms, status=%s",
@@ -386,8 +386,8 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 								// Compute planned backoff delay now so we can subtract it from wait budget
 								const delay = calculateDelay(
 									attempt,
-									retryConfig.minDelayMillis,
-									retryConfig.maxDelayMillis,
+									retryConfig.minBaseDelayMillis,
+									retryConfig.maxBaseDelayMillis,
 								);
 								// Recompute remaining budget from original request each time to avoid double-subtraction
 								if (baselineCount !== undefined) {
@@ -1014,8 +1014,8 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				this.consecutiveFailures++;
 				const delay = calculateDelay(
 					this.consecutiveFailures - 1,
-					this.retryConfig.minDelayMillis,
-					this.retryConfig.maxDelayMillis,
+					this.retryConfig.minBaseDelayMillis,
+					this.retryConfig.maxBaseDelayMillis,
 				);
 				debugSession(
 					"[%s] [PUMP] session creation failed, backing off for %dms",
@@ -1258,8 +1258,8 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 		// Calculate backoff delay
 		const delay = calculateDelay(
 			this.consecutiveFailures - 1,
-			this.retryConfig.minDelayMillis,
-			this.retryConfig.maxDelayMillis,
+			this.retryConfig.minBaseDelayMillis,
+			this.retryConfig.maxBaseDelayMillis,
 		);
 		debugSession("[%s] backing off for %dms", this.streamName, delay);
 		await sleep(delay);

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -187,7 +187,7 @@ export class S2STransport implements SessionTransport {
 
 		// Apply connection timeout if configured
 		const connectionTimeout =
-			this.transportConfig.retry?.connectionTimeoutMillis ?? 5000;
+			this.transportConfig.connectionTimeoutMillis ?? 3000;
 
 		let timeoutId: NodeJS.Timeout | undefined;
 		const timeoutPromise = new Promise<never>((_, reject) => {

--- a/packages/streamstore/src/lib/stream/types.ts
+++ b/packages/streamstore/src/lib/stream/types.ts
@@ -231,6 +231,14 @@ export interface TransportConfig {
 	 */
 	basinName?: string;
 	/**
+	 * Maximum time in milliseconds to wait for an append ack before timing out.
+	 */
+	requestTimeoutMillis?: number;
+	/**
+	 * Maximum time in milliseconds to wait for connection establishment.
+	 */
+	connectionTimeoutMillis?: number;
+	/**
 	 * Retry configuration inherited from the top-level client
 	 */
 	retry?: RetryConfig;

--- a/packages/streamstore/src/s2.ts
+++ b/packages/streamstore/src/s2.ts
@@ -48,7 +48,16 @@ export class S2 {
 	 */
 	constructor(options: S2ClientOptions) {
 		this.accessToken = Redacted.make(options.accessToken);
-		this.retryConfig = options.retry ?? {};
+		// Merge timeout config: top-level options take precedence over retry.* for backwards compatibility
+		this.retryConfig = {
+			...options.retry,
+			...(options.requestTimeoutMillis !== undefined && {
+				requestTimeoutMillis: options.requestTimeoutMillis,
+			}),
+			...(options.connectionTimeoutMillis !== undefined && {
+				connectionTimeoutMillis: options.connectionTimeoutMillis,
+			}),
+		};
 		this.endpoints =
 			options.endpoints instanceof S2Endpoints
 				? options.endpoints

--- a/packages/streamstore/src/streams.ts
+++ b/packages/streamstore/src/streams.ts
@@ -124,8 +124,7 @@ export class S2Streams {
 	 * List all streams in the basin with automatic pagination.
 	 * Returns a lazy async iterable that fetches pages as needed.
 	 *
-	 * @param includeDeleted - Include deleted streams (default: false)
-	 * @param args - Optional filtering options: `prefix` to filter by name prefix, `limit` for max results per page
+	 * @param args - Optional options: `prefix` to filter by name prefix, `limit` for max results per page, `includeDeleted` to include streams pending deletion
 	 *
 	 * @example
 	 * ```ts
@@ -135,17 +134,17 @@ export class S2Streams {
 	 * ```
 	 */
 	public listAll(
-		includeDeleted = false,
 		args?: Types.ListAllStreamsInput,
 		options?: S2RequestOptions,
 	): AsyncIterable<Types.StreamInfo> {
+		const { includeDeleted, ...listArgs } = args ?? {};
 		return paginate(
 			(a) =>
 				this.list(a, options).then((r) => ({
 					items: r.streams.filter((s) => includeDeleted || !s.deletedAt),
 					hasMore: r.hasMore,
 				})),
-			args ?? {},
+			listArgs,
 			(stream) => stream.name,
 		);
 	}

--- a/packages/streamstore/src/tests/correctness.e2e.test.ts
+++ b/packages/streamstore/src/tests/correctness.e2e.test.ts
@@ -42,8 +42,8 @@ describeIf("Correctness Integration Tests", () => {
 		const retryConfig = {
 			appendRetryPolicy: "all" as const,
 			maxAttempts: 65536,
-			minDelayMillis: 1000,
-			maxDelayMillis: 1000,
+			minBaseDelayMillis: 1000,
+			maxBaseDelayMillis: 1000,
 			requestTimeoutMillis: 5_000,
 		};
 

--- a/packages/streamstore/src/tests/retry.test.ts
+++ b/packages/streamstore/src/tests/retry.test.ts
@@ -106,7 +106,7 @@ describe("Retry Logic", () => {
 			expect(DEFAULT_RETRY_CONFIG.maxDelayMillis).toBe(1000);
 			expect(DEFAULT_RETRY_CONFIG.appendRetryPolicy).toBe("all");
 			expect(DEFAULT_RETRY_CONFIG.requestTimeoutMillis).toBe(5000);
-			expect(DEFAULT_RETRY_CONFIG.connectionTimeoutMillis).toBe(5000);
+			expect(DEFAULT_RETRY_CONFIG.connectionTimeoutMillis).toBe(3000);
 		});
 	});
 });

--- a/packages/streamstore/src/tests/retry.test.ts
+++ b/packages/streamstore/src/tests/retry.test.ts
@@ -22,7 +22,7 @@ describe("Retry Logic", () => {
 				.mockResolvedValue("success");
 
 			const result = await withRetries(
-				{ maxAttempts: 3, minDelayMillis: 1, maxDelayMillis: 1 },
+				{ maxAttempts: 3, minBaseDelayMillis: 1, maxBaseDelayMillis: 1 },
 				fn,
 			);
 
@@ -36,7 +36,7 @@ describe("Retry Logic", () => {
 
 			await expect(
 				withRetries(
-					{ maxAttempts: 3, minDelayMillis: 1, maxDelayMillis: 1 },
+					{ maxAttempts: 3, minBaseDelayMillis: 1, maxBaseDelayMillis: 1 },
 					fn,
 				),
 			).rejects.toThrow(error);
@@ -53,7 +53,7 @@ describe("Retry Logic", () => {
 				.mockResolvedValue("success");
 
 			const result = await withRetries(
-				{ maxAttempts: 3, minDelayMillis: 1, maxDelayMillis: 1 },
+				{ maxAttempts: 3, minBaseDelayMillis: 1, maxBaseDelayMillis: 1 },
 				fn,
 			);
 
@@ -67,7 +67,7 @@ describe("Retry Logic", () => {
 
 			await expect(
 				withRetries(
-					{ maxAttempts: 2, minDelayMillis: 1, maxDelayMillis: 1 },
+					{ maxAttempts: 2, minBaseDelayMillis: 1, maxBaseDelayMillis: 1 },
 					fn,
 				),
 			).rejects.toThrow(error);
@@ -82,7 +82,7 @@ describe("Retry Logic", () => {
 
 			await expect(
 				withRetries(
-					{ maxAttempts: 1, minDelayMillis: 1, maxDelayMillis: 1 },
+					{ maxAttempts: 1, minBaseDelayMillis: 1, maxBaseDelayMillis: 1 },
 					fn,
 				),
 			).rejects.toThrow(error);
@@ -102,8 +102,8 @@ describe("Retry Logic", () => {
 	describe("DEFAULT_RETRY_CONFIG", () => {
 		it("should have correct default values", () => {
 			expect(DEFAULT_RETRY_CONFIG.maxAttempts).toBe(3);
-			expect(DEFAULT_RETRY_CONFIG.minDelayMillis).toBe(100);
-			expect(DEFAULT_RETRY_CONFIG.maxDelayMillis).toBe(1000);
+			expect(DEFAULT_RETRY_CONFIG.minBaseDelayMillis).toBe(100);
+			expect(DEFAULT_RETRY_CONFIG.maxBaseDelayMillis).toBe(1000);
 			expect(DEFAULT_RETRY_CONFIG.appendRetryPolicy).toBe("all");
 			expect(DEFAULT_RETRY_CONFIG.requestTimeoutMillis).toBe(5000);
 			expect(DEFAULT_RETRY_CONFIG.connectionTimeoutMillis).toBe(3000);

--- a/packages/streamstore/src/tests/retryAppendSession.test.ts
+++ b/packages/streamstore/src/tests/retryAppendSession.test.ts
@@ -237,8 +237,8 @@ describe("AppendSessionImpl (unit)", () => {
 			},
 			undefined,
 			{
-				minDelayMillis: 1,
-				maxDelayMillis: 1,
+				minBaseDelayMillis: 1,
+				maxBaseDelayMillis: 1,
 				maxAttempts: 2,
 				appendRetryPolicy: "all",
 			},
@@ -262,8 +262,8 @@ describe("AppendSessionImpl (unit)", () => {
 			async () => new FakeTransportAppendSession({ submitError: error }),
 			undefined,
 			{
-				minDelayMillis: 1,
-				maxDelayMillis: 1,
+				minBaseDelayMillis: 1,
+				maxBaseDelayMillis: 1,
 				maxAttempts: 1,
 				appendRetryPolicy: "all",
 			},
@@ -284,8 +284,8 @@ describe("AppendSessionImpl (unit)", () => {
 			async () => new FakeTransportAppendSession({ submitError: error }),
 			undefined,
 			{
-				minDelayMillis: 1,
-				maxDelayMillis: 1,
+				minBaseDelayMillis: 1,
+				maxBaseDelayMillis: 1,
 				maxAttempts: 2,
 				appendRetryPolicy: "noSideEffects",
 			},
@@ -304,8 +304,8 @@ describe("AppendSessionImpl (unit)", () => {
 			async () => new FakeTransportAppendSession({ submitError: error }),
 			undefined,
 			{
-				minDelayMillis: 1,
-				maxDelayMillis: 1,
+				minBaseDelayMillis: 1,
+				maxBaseDelayMillis: 1,
 				maxAttempts: 2,
 				appendRetryPolicy: "noSideEffects",
 			},
@@ -338,7 +338,7 @@ describe("AppendSessionImpl (unit)", () => {
 		const session = await AppendSessionImpl.create(
 			async () => new FakeTransportAppendSession({ customAcks: [ack1, ack2] }),
 			undefined,
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 1 }, // No retries
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 }, // No retries
 		);
 
 		// First submit should succeed
@@ -394,7 +394,7 @@ describe("AppendSessionImpl (unit)", () => {
 		const session = await AppendSessionImpl.create(
 			async () => new FakeTransportAppendSession({ customAcks: [ack1, ack2] }),
 			undefined,
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 1 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
 		);
 
 		// First submit should succeed

--- a/packages/streamstore/src/tests/retryReadSession.test.ts
+++ b/packages/streamstore/src/tests/retryReadSession.test.ts
@@ -155,7 +155,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ count: 10 }, // Request 10 records
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records
@@ -199,7 +199,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ bytes: 500 }, // Request 500 bytes
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records
@@ -243,7 +243,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ wait: 10 }, // Wait up to 10 seconds
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records
@@ -289,7 +289,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ seq_num: 100 }, // Start from seq_num 100
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records (including through retry)
@@ -332,7 +332,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ until: 1000 }, // Read until seq_num 1000
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records
@@ -381,7 +381,7 @@ describe("ReadSession (unit)", () => {
 				wait: 30,
 				until: 1000,
 			},
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 2 },
 		);
 
 		// Consume all records
@@ -428,7 +428,7 @@ describe("ReadSession (unit)", () => {
 				});
 			},
 			{ count: 10 },
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 3 }, // Allow 2 retries
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 3 }, // Allow 2 retries
 		);
 
 		// Try to consume the stream - should fail after exhausting retries
@@ -481,7 +481,7 @@ describe("ReadSession (unit)", () => {
 				return new FakeReadSession({ records: [] });
 			},
 			{ seq_num: 0, count: 100 },
-			{ minDelayMillis: 1, maxDelayMillis: 1, maxAttempts: 3 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 3 },
 		);
 
 		// Drain the session

--- a/packages/streamstore/src/tests/unaryAppendRetryPolicy.test.ts
+++ b/packages/streamstore/src/tests/unaryAppendRetryPolicy.test.ts
@@ -28,8 +28,8 @@ describe("Unary append retry policy", () => {
 		const stream = new S2Stream("test", {} as any, {} as any, {
 			appendRetryPolicy: "noSideEffects",
 			maxAttempts: 2,
-			minDelayMillis: 1,
-			maxDelayMillis: 1,
+			minBaseDelayMillis: 1,
+			maxBaseDelayMillis: 1,
 		});
 
 		const ack = await stream.append(
@@ -51,8 +51,8 @@ describe("Unary append retry policy", () => {
 		const stream = new S2Stream("test", {} as any, {} as any, {
 			appendRetryPolicy: "noSideEffects",
 			maxAttempts: 2,
-			minDelayMillis: 1,
-			maxDelayMillis: 1,
+			minBaseDelayMillis: 1,
+			maxBaseDelayMillis: 1,
 		});
 
 		await expect(


### PR DESCRIPTION
  - Add examples/docs/ with runnable TypeScript snippets for documentation extraction
  - Promote connectionTimeoutMillis and requestTimeoutMillis to top-level client options
  - Deprecate timeout settings under retry config (backwards-compatible)
  - Reduce default connection timeout from 5s to 3s
  - Change basins.listAll() and streams.listAll() to accept includeDeleted in options object instead of as first positional argument