### PR TITLE
fix: enforce 1 MiB minimum for maxInflightBytes

### DIFF
--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -648,11 +648,15 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 			...config,
 		};
 		this.requestTimeoutMillis = this.retryConfig.requestTimeoutMillis;
-		// Clamp maxInflightBytes to at least 1 MiB
-		this.maxQueuedBytes = Math.max(
-			MIN_MAX_INFLIGHT_BYTES,
-			this.sessionOptions?.maxInflightBytes ?? DEFAULT_MAX_INFLIGHT_BYTES,
-		);
+		const maxInflightBytes =
+			this.sessionOptions?.maxInflightBytes ?? DEFAULT_MAX_INFLIGHT_BYTES;
+		if (maxInflightBytes < MIN_MAX_INFLIGHT_BYTES) {
+			throw new S2Error({
+				message: `maxInflightBytes must be at least ${MIN_MAX_INFLIGHT_BYTES}`,
+				origin: "sdk",
+			});
+		}
+		this.maxQueuedBytes = maxInflightBytes;
 		// Clamp maxInflightBatches to at least 1 if set
 		this.maxInflightBatches =
 			this.sessionOptions?.maxInflightBatches !== undefined


### PR DESCRIPTION
## Summary
- Throw `S2Error` with `origin: "sdk"` if `maxInflightBytes < 1 MiB` instead of silently clamping
- Matches Rust SDK behavior (returns `ValidationError`, session/append.rs:118-119)
- Aligns with team decision to standardize on returning errors for config validation

## Test plan
- [x] Existing tests pass
- [ ] Add test for rejected config < 1 MiB (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)