### PR TITLE
fix: exclude Bun from http2 auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ const stream = basin.stream(streamName, {
 ```
 <!-- snippet:end force-transport -->
 
+... or rely on environment auto-detection to specify the transport, as is the default behavior.
+
+> [!IMPORTANT]
+> HTTP/2 library use, required for `s2s`, is currently only for Node.js and Deno. It is disabled by default for Bun (see [tracking issue](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113)), but can be forced using the mechanism described above.
+
 ## Patterns
 
 For higher-level, more opinionated building blocks (typed append/read sessions, framing, dedupe helpers), see the [patterns](packages/patterns/README.md) package.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ const stream = basin.stream(streamName, {
 ... or rely on environment auto-detection to specify the transport, as is the default behavior.
 
 > [!IMPORTANT]
-> HTTP/2 library use, required for `s2s`, is currently only for Node.js and Deno. It is disabled by default for Bun (see [tracking issue](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113)), but can be forced using the mechanism described above.
+> HTTP/2 library use, required for `s2s`, is currently only enabled by default for Node.js and Deno. Bun defaults to HTTP/1 (see [tracking issue](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113)), but can be forced using the mechanism described above.
 
 ## Patterns
 

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -54,9 +54,13 @@ export function supportsHttp2(): boolean {
 	switch (runtime) {
 		case "node":
 		case "deno":
+			return true;
+
 		case "bun":
 			// via node:http2
-			return true;
+			// NOTE: bun's http2 support appears to be buggy, re: https://github.com/s2-streamstore/s2-sdk-typescript/issues/113
+			// so we disable http2 for now
+			return false;
 
 		case "browser":
 		case "workerd":


### PR DESCRIPTION
Related to problems with Bun tracked in https://github.com/s2-streamstore/s2-sdk-typescript/issues/113