### PR TITLE
fix: Deno fetch support

### DIFF
--- a/.changeset/blue-singers-ask.md
+++ b/.changeset/blue-singers-ask.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Add Deno support (for fetch transports)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,35 @@ jobs:
           S2_BASIN: ${{ secrets.S2_BASIN }}
         run: bun run test
 
+  test-deno:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Run Deno e2e tests
+        env:
+          S2_ACCESS_TOKEN: ${{ secrets.S2_ACCESS_TOKEN }}
+          S2_BASIN: ${{ secrets.S2_BASIN }}
+        run: bun run test:deno
+
   build-s2-lite:
     name: Build S2-lite
     uses: s2-streamstore/s2/.github/workflows/build-s2-lite.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # local examples
 packages/*/examples/local/*
+examples/local/*
 
 # browser example build output
 packages/*/examples/browser/app.js

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "imports": {
     "@s2-dev/streamstore": "./packages/streamstore/dist/esm/index.js",
     "@std/assert": "jsr:@std/assert@^1",
+    "@protobuf-ts/runtime": "npm:@protobuf-ts/runtime@^2",
     "debug": "npm:debug@^4"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@s2-dev/streamstore": "./packages/streamstore/dist/esm/index.js",
+    "@std/assert": "jsr:@std/assert@^1",
+    "debug": "npm:debug@^4"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -18,6 +18,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
+      "npm:@protobuf-ts/runtime@2",
       "npm:debug@4"
     ],
     "packageJson": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,61 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.12"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1",
+      "npm:debug@4"
+    ],
+    "packageJson": {
+      "dependencies": [
+        "npm:@arethetypeswrong/cli@~0.18.2",
+        "npm:@biomejs/biome@2.2.5",
+        "npm:@changesets/cli@^2.29.7",
+        "npm:@hey-api/openapi-ts@~0.86.12",
+        "npm:@protobuf-ts/plugin@^2.11.1",
+        "npm:@types/bun@^1.3.2",
+        "npm:@types/debug@^4.1.12",
+        "npm:openapi-typescript@^7.10.1",
+        "npm:protoc@^33.1.0",
+        "npm:typedoc@~0.28.14",
+        "npm:vitest@^4.0.10"
+      ]
+    },
+    "members": {
+      "packages/patterns": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@ai-sdk/openai@^2.0.68",
+            "npm:@msgpack/msgpack@^3.1.2",
+            "npm:ai@^5.0.95",
+            "npm:debug@^4.4.3",
+            "npm:nanoid@^3.3.11",
+            "npm:tsx@^4.19.2"
+          ]
+        }
+      },
+      "packages/streamstore": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@protobuf-ts/runtime@^2.11.1",
+            "npm:debug@^4.4.3"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -18,5 +18,6 @@
 			"@s2-dev/streamstore-patterns/*": ["packages/patterns/src/*"]
 		}
 	},
-	"include": ["./**/*.ts"]
+	"include": ["./**/*.ts"],
+	"exclude": ["./local/**"]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:core": "bun run --cwd packages/streamstore build",
     "build:patterns": "bun run --cwd packages/patterns build",
     "test": "vitest --run",
+    "test:deno": "deno test --no-check --allow-env --allow-net --config deno.json packages/streamstore/src/tests/deno.e2e.test.ts",
     "test:core": "bun run --cwd packages/streamstore test",
     "test:patterns": "bun run --cwd packages/patterns test",
     "check": "bun run snippets && bun run check:snippets && biome check && bun run build:core && bun run --cwd packages/streamstore check && bun run --cwd packages/patterns check",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "version-with-docs": "changeset version && bun run gen:version && bun run docs && git add docs",
     "gen:version": "bun run --cwd packages/streamstore gen:version",
     "release": "changeset publish",
-    "gen:openapi": "openapi-ts",
+    "gen:openapi": "openapi-ts && bun scripts/patch-codegen.ts",
     "gen:proto": "protoc --ts_out packages/streamstore/src/generated/proto --ts_opt ts_nocheck --proto_path s2-specs s2-specs/s2/v1/s2.proto && mv packages/streamstore/src/generated/proto/s2/v1/s2.ts packages/streamstore/src/generated/proto/s2.ts",
     "docs": "typedoc",
     "snippets": "node scripts/sync-snippets.mjs",

--- a/packages/streamstore/src/generated/client/client.gen.ts
+++ b/packages/streamstore/src/generated/client/client.gen.ts
@@ -80,7 +80,17 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     const requestInit: ReqInit = {
       redirect: 'follow',
-      ...opts,
+      cache: opts.cache,
+      credentials: opts.credentials,
+      headers: opts.headers,
+      integrity: opts.integrity,
+      keepalive: opts.keepalive,
+      method: opts.method,
+      mode: opts.mode,
+      priority: opts.priority,
+      referrer: opts.referrer,
+      referrerPolicy: opts.referrerPolicy,
+      signal: opts.signal,
       body: getValidRequestBody(opts),
     };
 

--- a/packages/streamstore/src/generated/client/client.gen.ts
+++ b/packages/streamstore/src/generated/client/client.gen.ts
@@ -78,8 +78,8 @@ export const createClient = (config: Config = {}): Client => {
   const request: Client['request'] = async (options) => {
     // @ts-expect-error
     const { opts, url } = await beforeRequest(options);
-    const requestInit: ReqInit = {
-      redirect: 'follow',
+    const requestInit = {
+      redirect: opts.redirect ?? 'follow',
       cache: opts.cache,
       credentials: opts.credentials,
       headers: opts.headers,
@@ -92,7 +92,8 @@ export const createClient = (config: Config = {}): Client => {
       referrerPolicy: opts.referrerPolicy,
       signal: opts.signal,
       body: getValidRequestBody(opts),
-    };
+      ...('duplex' in opts ? { duplex: (opts as any).duplex } : undefined),
+    } as ReqInit;
 
     let request = new Request(url, requestInit);
 

--- a/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
+++ b/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
@@ -125,10 +125,16 @@ export const createSseClient = <TData = unknown>({
       }
 
       try {
-        const { fetch: _fetchOpt, serializedBody: _sb, ...requestOptions } = options;
         const requestInit: RequestInit = {
-          redirect: 'follow',
-          ...requestOptions,
+          redirect: options.redirect ?? 'follow',
+          cache: options.cache,
+          credentials: options.credentials,
+          integrity: options.integrity,
+          keepalive: options.keepalive,
+          method: options.method,
+          mode: options.mode,
+          referrer: options.referrer,
+          referrerPolicy: options.referrerPolicy,
           body: options.serializedBody,
           headers,
           signal,

--- a/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
+++ b/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
@@ -133,6 +133,7 @@ export const createSseClient = <TData = unknown>({
           keepalive: options.keepalive,
           method: options.method,
           mode: options.mode,
+          priority: options.priority,
           referrer: options.referrer,
           referrerPolicy: options.referrerPolicy,
           body: options.serializedBody,

--- a/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
+++ b/packages/streamstore/src/generated/core/serverSentEvents.gen.ts
@@ -125,9 +125,10 @@ export const createSseClient = <TData = unknown>({
       }
 
       try {
+        const { fetch: _fetchOpt, serializedBody: _sb, ...requestOptions } = options;
         const requestInit: RequestInit = {
           redirect: 'follow',
-          ...options,
+          ...requestOptions,
           body: options.serializedBody,
           headers,
           signal,

--- a/packages/streamstore/src/generated/types.gen.ts
+++ b/packages/streamstore/src/generated/types.gen.ts
@@ -187,7 +187,7 @@ export type CreateBasinRequest = {
 };
 
 export type CreateOrReconfigureBasinRequest = {
-    config?: null | BasinConfig;
+    config?: null | BasinReconfiguration;
     scope?: null | BasinScope;
 };
 
@@ -1052,7 +1052,7 @@ export type ReconfigureStreamResponses = {
 export type ReconfigureStreamResponse = ReconfigureStreamResponses[keyof ReconfigureStreamResponses];
 
 export type CreateOrReconfigureStreamData = {
-    body?: null | StreamConfig;
+    body?: null | StreamReconfiguration;
     path: {
         /**
          * Stream name.

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -56,8 +56,8 @@ export function supportsHttp2(): boolean {
 			return true;
 
 		case "deno":
-			// Deno's node:http2 is missing setLocalWindowSize and has
-			// data-chunking differences that break the s2s frame parser.
+			// Deno's node:http2 has data-chunking differences that cause
+			// "premature EOF" errors in the s2s frame parser.
 			// Fall back to fetch transport until Deno's compat improves.
 			return false;
 

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -53,8 +53,13 @@ export function supportsHttp2(): boolean {
 
 	switch (runtime) {
 		case "node":
-		case "deno":
 			return true;
+
+		case "deno":
+			// Deno's node:http2 is missing setLocalWindowSize and has
+			// data-chunking differences that break the s2s frame parser.
+			// Fall back to fetch transport until Deno's compat improves.
+			return false;
 
 		case "bun":
 			// via node:http2

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -172,7 +172,12 @@ export class S2STransport implements SessionTransport {
 				client.once("connect", () => {
 					// Guard against session being destroyed before connect fires
 					if (client.destroyed) return;
-					client.setLocalWindowSize(10 * 1024 * 1024);
+					try {
+						client.setLocalWindowSize(10 * 1024 * 1024);
+					} catch {
+						// Not implemented in all runtimes (e.g. Deno).
+						// This is a performance optimization, not required for correctness.
+					}
 					resolve(client);
 				});
 

--- a/packages/streamstore/src/tests/deno.e2e.test.ts
+++ b/packages/streamstore/src/tests/deno.e2e.test.ts
@@ -11,7 +11,7 @@
  *   S2_ACCESS_TOKEN=... S2_BASIN=... deno test --no-check --allow-env --allow-net --config deno.json packages/streamstore/src/tests/deno.e2e.test.ts
  */
 
-import { AppendInput, AppendRecord, S2, S2Stream } from "@s2-dev/streamstore";
+import { AppendInput, AppendRecord, S2 } from "@s2-dev/streamstore";
 import { assert, assertEquals, assertExists } from "@std/assert";
 
 const accessToken = Deno.env.get("S2_ACCESS_TOKEN");

--- a/packages/streamstore/src/tests/deno.e2e.test.ts
+++ b/packages/streamstore/src/tests/deno.e2e.test.ts
@@ -11,12 +11,8 @@
  *   S2_ACCESS_TOKEN=... S2_BASIN=... deno test --no-check --allow-env --allow-net --config deno.json packages/streamstore/src/tests/deno.e2e.test.ts
  */
 
-import { S2, AppendInput, AppendRecord, S2Stream } from "@s2-dev/streamstore";
-import {
-	assert,
-	assertEquals,
-	assertExists,
-} from "@std/assert";
+import { AppendInput, AppendRecord, S2, S2Stream } from "@s2-dev/streamstore";
+import { assert, assertEquals, assertExists } from "@std/assert";
 
 const accessToken = Deno.env.get("S2_ACCESS_TOKEN");
 const basinName = Deno.env.get("S2_BASIN");

--- a/packages/streamstore/src/tests/deno.e2e.test.ts
+++ b/packages/streamstore/src/tests/deno.e2e.test.ts
@@ -1,0 +1,109 @@
+// deno-lint-ignore-file
+/// <reference lib="deno.ns" />
+
+/**
+ * Deno e2e smoke tests.
+ *
+ * These exercise the SDK under Deno's runtime to verify fetch compatibility
+ * and basic operations work end-to-end.
+ *
+ * Usage (from repo root, after `bun run build`):
+ *   S2_ACCESS_TOKEN=... S2_BASIN=... deno test --no-check --allow-env --allow-net --config deno.json packages/streamstore/src/tests/deno.e2e.test.ts
+ */
+
+import { S2, AppendInput, AppendRecord } from "@s2-dev/streamstore";
+import {
+	assert,
+	assertEquals,
+	assertExists,
+} from "@std/assert";
+
+const accessToken = Deno.env.get("S2_ACCESS_TOKEN");
+const basinName = Deno.env.get("S2_BASIN");
+
+function shouldSkip(): boolean {
+	if (!accessToken || !basinName) {
+		console.log("Skipping: S2_ACCESS_TOKEN and S2_BASIN must be set");
+		return true;
+	}
+	return false;
+}
+
+function makeClient(): InstanceType<typeof S2> {
+	return new S2({ accessToken: accessToken! });
+}
+
+function makeStreamName(prefix: string): string {
+	return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// The SDK doesn't always fully consume response bodies, so we disable
+// Deno's resource/op leak detection for these e2e tests.
+const sanitize = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test({
+	name: "list basins",
+	ignore: shouldSkip(),
+	...sanitize,
+	async fn() {
+		const s2 = makeClient();
+		const resp = await s2.basins.list();
+		assert(Array.isArray(resp.basins));
+	},
+});
+
+Deno.test({
+	name: "check tail on fresh stream",
+	ignore: shouldSkip(),
+	...sanitize,
+	async fn() {
+		const s2 = makeClient();
+		const basin = s2.basin(basinName!);
+		const streamName = makeStreamName("deno-tail");
+		await basin.streams.create({ stream: streamName });
+		try {
+			const stream = basin.stream(streamName);
+			const resp = await stream.checkTail();
+			assertExists(resp);
+			assertExists(resp.tail);
+			assertEquals(resp.tail.seqNum, 0);
+		} finally {
+			await basin.streams.delete({ stream: streamName });
+		}
+	},
+});
+
+Deno.test({
+	name: "append and read",
+	ignore: shouldSkip(),
+	...sanitize,
+	async fn() {
+		const s2 = makeClient();
+		const basin = s2.basin(basinName!);
+
+		const streamName = makeStreamName("deno-rw");
+		await basin.streams.create({ stream: streamName });
+
+		try {
+			const stream = basin.stream(streamName);
+
+			const input = AppendInput.create([
+				AppendRecord.string({ body: "hello from deno" }),
+				AppendRecord.string({ body: "second record" }),
+			]);
+			const ack = await stream.append(input);
+			assertExists(ack);
+			assertEquals(ack.start.seqNum, 0);
+			assertEquals(ack.end.seqNum, 2);
+
+			const batch = await stream.read({
+				start: { from: { seqNum: 0 }, clamp: true },
+			});
+			assert(batch.records.length >= 2);
+			assertEquals(batch.records[0]!.body, "hello from deno");
+			assertEquals(batch.records[1]!.body, "second record");
+		} finally {
+			await basin.streams.delete({ stream: streamName });
+		}
+	},
+});

--- a/packages/streamstore/src/tests/deno.e2e.test.ts
+++ b/packages/streamstore/src/tests/deno.e2e.test.ts
@@ -11,7 +11,7 @@
  *   S2_ACCESS_TOKEN=... S2_BASIN=... deno test --no-check --allow-env --allow-net --config deno.json packages/streamstore/src/tests/deno.e2e.test.ts
  */
 
-import { S2, AppendInput, AppendRecord } from "@s2-dev/streamstore";
+import { S2, AppendInput, AppendRecord, S2Stream } from "@s2-dev/streamstore";
 import {
 	assert,
 	assertEquals,
@@ -102,6 +102,48 @@ Deno.test({
 			assert(batch.records.length >= 2);
 			assertEquals(batch.records[0]!.body, "hello from deno");
 			assertEquals(batch.records[1]!.body, "second record");
+		} finally {
+			await basin.streams.delete({ stream: streamName });
+		}
+	},
+});
+
+Deno.test({
+	name: "read session",
+	ignore: shouldSkip(),
+	...sanitize,
+	async fn() {
+		const s2 = makeClient();
+		const basin = s2.basin(basinName!);
+
+		const streamName = makeStreamName("deno-rs");
+		await basin.streams.create({ stream: streamName });
+
+		try {
+			const stream = basin.stream(streamName);
+
+			// Append some records first
+			const input = AppendInput.create([
+				AppendRecord.string({ body: "rs-record-0" }),
+				AppendRecord.string({ body: "rs-record-1" }),
+				AppendRecord.string({ body: "rs-record-2" }),
+			]);
+			await stream.append(input);
+
+			// Open a read session
+			const session = await stream.readSession({
+				start: { from: { seqNum: 0 }, clamp: true },
+				stop: { limits: { count: 3 } },
+			});
+
+			const records: string[] = [];
+			for await (const record of session) {
+				records.push(record.body as string);
+			}
+
+			assertEquals(records, ["rs-record-0", "rs-record-1", "rs-record-2"]);
+
+			await stream.close();
 		} finally {
 			await basin.streams.delete({ stream: streamName });
 		}

--- a/packages/streamstore/tsconfig.json
+++ b/packages/streamstore/tsconfig.json
@@ -26,5 +26,5 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "include": ["src/**/*", "examples/**/*"],
-  "exclude": ["src/generated", "dist"]
+  "exclude": ["src/generated", "src/tests/deno.e2e.test.ts", "dist"]
 }

--- a/scripts/patch-codegen.ts
+++ b/scripts/patch-codegen.ts
@@ -101,6 +101,7 @@ patchFile("core/serverSentEvents.gen.ts", [
 			"          keepalive: options.keepalive,",
 			"          method: options.method,",
 			"          mode: options.mode,",
+			"          priority: options.priority,",
 			"          referrer: options.referrer,",
 			"          referrerPolicy: options.referrerPolicy,",
 			"          body: options.serializedBody,",

--- a/scripts/patch-codegen.ts
+++ b/scripts/patch-codegen.ts
@@ -60,8 +60,8 @@ patchFile("client/client.gen.ts", [
 			"    };",
 		].join("\n"),
 		to: [
-			"    const requestInit: ReqInit = {",
-			"      redirect: 'follow',",
+			"    const requestInit = {",
+			"      redirect: opts.redirect ?? 'follow',",
 			"      cache: opts.cache,",
 			"      credentials: opts.credentials,",
 			"      headers: opts.headers,",
@@ -74,7 +74,8 @@ patchFile("client/client.gen.ts", [
 			"      referrerPolicy: opts.referrerPolicy,",
 			"      signal: opts.signal,",
 			"      body: getValidRequestBody(opts),",
-			"    };",
+			"      ...('duplex' in opts ? { duplex: (opts as any).duplex } : undefined),",
+			"    } as ReqInit;",
 		].join("\n"),
 	},
 ]);

--- a/scripts/patch-codegen.ts
+++ b/scripts/patch-codegen.ts
@@ -41,7 +41,7 @@ function patchFile(relPath: string, patches: Array<{ from: string; to: string }>
 			console.error(`  Looking for: ${from.slice(0, 80)}...`);
 			process.exit(1);
 		}
-		content = content.replace(from, to);
+		content = content.replaceAll(from, to.replaceAll("$", "$$$$"));
 		patchCount++;
 	}
 
@@ -93,10 +93,16 @@ patchFile("core/serverSentEvents.gen.ts", [
 			"        };",
 		].join("\n"),
 		to: [
-			"        const { fetch: _fetchOpt, serializedBody: _sb, ...requestOptions } = options;",
 			"        const requestInit: RequestInit = {",
-			"          redirect: 'follow',",
-			"          ...requestOptions,",
+			"          redirect: options.redirect ?? 'follow',",
+			"          cache: options.cache,",
+			"          credentials: options.credentials,",
+			"          integrity: options.integrity,",
+			"          keepalive: options.keepalive,",
+			"          method: options.method,",
+			"          mode: options.mode,",
+			"          referrer: options.referrer,",
+			"          referrerPolicy: options.referrerPolicy,",
 			"          body: options.serializedBody,",
 			"          headers,",
 			"          signal,",

--- a/scripts/patch-codegen.ts
+++ b/scripts/patch-codegen.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+
+/**
+ * Post-codegen patch script.
+ *
+ * Fixes generated @hey-api/openapi-ts output for Deno compatibility.
+ *
+ * Problem: The generated client spreads the entire `opts` object into
+ * `new Request(url, requestInit)`. Node ignores unknown properties, but
+ * Deno's Request constructor is strict and throws on non-standard fields
+ * like `baseUrl`, `fetch`, `auth`, `parseAs`, etc.
+ *
+ * This script rewrites the requestInit construction to only pass valid
+ * RequestInit properties.
+ *
+ * Run after `openapi-ts`:
+ *   bun scripts/patch-codegen.ts
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const GENERATED_DIR = join(
+	import.meta.dir,
+	"..",
+	"packages",
+	"streamstore",
+	"src",
+	"generated",
+);
+
+let patchCount = 0;
+
+function patchFile(relPath: string, patches: Array<{ from: string; to: string }>) {
+	const filePath = join(GENERATED_DIR, relPath);
+	let content = readFileSync(filePath, "utf-8");
+
+	for (const { from, to } of patches) {
+		if (!content.includes(from)) {
+			console.error(`✗ Could not find expected pattern in ${relPath}:`);
+			console.error(`  Looking for: ${from.slice(0, 80)}...`);
+			process.exit(1);
+		}
+		content = content.replace(from, to);
+		patchCount++;
+	}
+
+	writeFileSync(filePath, content, "utf-8");
+	console.log(`✓ Patched ${relPath}`);
+}
+
+// Patch 1: client.gen.ts — only pass valid RequestInit properties to new Request()
+patchFile("client/client.gen.ts", [
+	{
+		from: [
+			"    const requestInit: ReqInit = {",
+			"      redirect: 'follow',",
+			"      ...opts,",
+			"      body: getValidRequestBody(opts),",
+			"    };",
+		].join("\n"),
+		to: [
+			"    const requestInit: ReqInit = {",
+			"      redirect: 'follow',",
+			"      cache: opts.cache,",
+			"      credentials: opts.credentials,",
+			"      headers: opts.headers,",
+			"      integrity: opts.integrity,",
+			"      keepalive: opts.keepalive,",
+			"      method: opts.method,",
+			"      mode: opts.mode,",
+			"      priority: opts.priority,",
+			"      referrer: opts.referrer,",
+			"      referrerPolicy: opts.referrerPolicy,",
+			"      signal: opts.signal,",
+			"      body: getValidRequestBody(opts),",
+			"    };",
+		].join("\n"),
+	},
+]);
+
+// Patch 2: serverSentEvents.gen.ts — strip non-RequestInit properties before spreading
+patchFile("core/serverSentEvents.gen.ts", [
+	{
+		from: [
+			"        const requestInit: RequestInit = {",
+			"          redirect: 'follow',",
+			"          ...options,",
+			"          body: options.serializedBody,",
+			"          headers,",
+			"          signal,",
+			"        };",
+		].join("\n"),
+		to: [
+			"        const { fetch: _fetchOpt, serializedBody: _sb, ...requestOptions } = options;",
+			"        const requestInit: RequestInit = {",
+			"          redirect: 'follow',",
+			"          ...requestOptions,",
+			"          body: options.serializedBody,",
+			"          headers,",
+			"          signal,",
+			"        };",
+		].join("\n"),
+	},
+]);
+
+console.log(`\n✓ Applied ${patchCount} patches for Deno compatibility`);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig(({ mode }) => ({
   },
   test: {
     env: loadEnv(mode, process.cwd(), ''),
+    // Deno tests use `deno test` directly — exclude from vitest
+    exclude: ['**/deno.e2e.test.ts', '**/node_modules/**'],
     // Run e2e tests in a separate pool with limited concurrency
     poolMatchGlobs: [['**/*.e2e.test.ts', 'forks']],
     poolOptions: {


### PR DESCRIPTION
Deno support was broken due to providing unknown properties in `Request` (an artifact of our use of generated clients from hey-api, which was spreading all options into `Request` including S2 specific vals like baseUrl). This was ignored in node/bun, but not Deno.

Adds a post-generation script for correcting this, as well as a basic e2e deno test.

I also tested out s2s transport, and ran into a few issues. Disabling it from autodetection for now.