### PR TITLE
Migrate default basin endpoint to b.s2.dev

### DIFF
--- a/packages/streamstore/src/basin.ts
+++ b/packages/streamstore/src/basin.ts
@@ -18,7 +18,7 @@ export class S2Basin {
 	public readonly streams: S2Streams;
 
 	/**
-	 * Create a basin-scoped client that talks to `https://{basin}.b.aws.s2.dev/v1`.
+	 * Create a basin-scoped client that talks to `https://{basin}.b.s2.dev/v1`.
 	 *
 	 * Use this to work with streams inside a single basin.
 	 * @param name Basin name

--- a/packages/streamstore/src/common.ts
+++ b/packages/streamstore/src/common.ts
@@ -106,7 +106,7 @@ export type S2ClientOptions = {
 	/**
 	 * Endpoint configuration for the S2 environment.
 	 *
-	 * Defaults to AWS (`aws.s2.dev` and `{basin}.b.aws.s2.dev`) with the API base path inferred as `/v1`.
+	 * Defaults to AWS (`aws.s2.dev` and `{basin}.b.s2.dev`) with the API base path inferred as `/v1`.
 	 */
 	endpoints?: S2Endpoints | S2EndpointsInit;
 	/**

--- a/packages/streamstore/src/endpoints.ts
+++ b/packages/streamstore/src/endpoints.ts
@@ -134,7 +134,7 @@ export type S2EndpointsInit = {
 };
 
 const DEFAULT_ACCOUNT_ENDPOINT = "aws.s2.dev";
-const DEFAULT_BASIN_ENDPOINT = "{basin}.b.aws.s2.dev";
+const DEFAULT_BASIN_ENDPOINT = "{basin}.b.s2.dev";
 
 /**
  * Endpoint configuration for the S2 environment.

--- a/packages/streamstore/src/tests/appendSession.test.ts
+++ b/packages/streamstore/src/tests/appendSession.test.ts
@@ -11,7 +11,7 @@ const fakeClient: any = {};
 
 const makeStream = (retry?: { maxAttempts?: number }) =>
 	new S2Stream("test-stream", fakeClient, {
-		baseUrl: "https://test.b.aws.s2.dev",
+		baseUrl: "https://test.b.s2.dev",
 		accessToken: Redacted.make("test-access-token"),
 		forceTransport: "fetch",
 		retry,

--- a/packages/streamstore/src/tests/batcher-session.test.ts
+++ b/packages/streamstore/src/tests/batcher-session.test.ts
@@ -9,7 +9,7 @@ import type { AppendAck } from "../types.js";
 const fakeClient: any = {};
 const makeStream = () =>
 	new S2Stream("test-stream", fakeClient, {
-		baseUrl: "https://test.b.aws.s2.dev",
+		baseUrl: "https://test.b.s2.dev",
 		accessToken: Redacted.make("test-access-token"),
 		forceTransport: "fetch",
 	});

--- a/packages/streamstore/src/tests/case-transform.test.ts
+++ b/packages/streamstore/src/tests/case-transform.test.ts
@@ -202,7 +202,13 @@ describe("case-transform", () => {
 			type Response = SDK.ListBasinsResponse;
 
 			const response: Response = {
-				basins: [{ name: "my-basin", scope: "aws:us-east-1", createdAt: "2024-01-01T00:00:00Z" }],
+				basins: [
+					{
+						name: "my-basin",
+						scope: "aws:us-east-1",
+						createdAt: "2024-01-01T00:00:00Z",
+					},
+				],
 				hasMore: false,
 			};
 

--- a/packages/streamstore/src/tests/case-transform.test.ts
+++ b/packages/streamstore/src/tests/case-transform.test.ts
@@ -202,7 +202,7 @@ describe("case-transform", () => {
 			type Response = SDK.ListBasinsResponse;
 
 			const response: Response = {
-				basins: [{ name: "my-basin", scope: "aws:us-east-1", state: "active" }],
+				basins: [{ name: "my-basin", scope: "aws:us-east-1", createdAt: "2024-01-01T00:00:00Z" }],
 				hasMore: false,
 			};
 

--- a/packages/streamstore/src/tests/endpoints.test.ts
+++ b/packages/streamstore/src/tests/endpoints.test.ts
@@ -6,7 +6,7 @@ describe("S2Endpoints", () => {
 		const endpoints = new S2Endpoints();
 		expect(endpoints.accountBaseUrl()).toBe("https://aws.s2.dev/v1");
 		expect(endpoints.basinBaseUrl("my-basin")).toBe(
-			"https://my-basin.b.aws.s2.dev/v1",
+			"https://my-basin.b.s2.dev/v1",
 		);
 		expect(endpoints.includeBasinHeader).toBe(false);
 	});


### PR DESCRIPTION
## Summary
- Updates default basin endpoint from `b.aws.s2.dev` to `b.s2.dev` in source code, JSDoc comments, and tests
- The `s2-specs` openapi.json and generated types were already updated via #173
- Files changed: `endpoints.ts`, `basin.ts`, `common.ts`, and 3 test files

## Test plan
- [ ] `bun test` passes with updated endpoint expectations
- [ ] Verify default basin URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)