### PR TITLE
fix(streamstore): handle truncated fetch SSE reads as errors

### DIFF
--- a/.changeset/fix-truncated-fetch-sse.md
+++ b/.changeset/fix-truncated-fetch-sse.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Treat truncated fetch SSE reads as retryable errors instead of silently ending the read session.

--- a/packages/streamstore/src/lib/event-stream.ts
+++ b/packages/streamstore/src/lib/event-stream.ts
@@ -3,6 +3,7 @@
  */
 
 import createDebug from "debug";
+import { S2Error } from "../error.js";
 
 const debug = createDebug("s2:event-stream");
 
@@ -54,7 +55,17 @@ export class EventStream<T>
 						const match = findBoundary(buffer);
 						if (!match) {
 							const chunk = await upstream.read();
-							if (chunk.done) return downstream.close();
+							if (chunk.done) {
+								if (buffer.length > 0) {
+									throw new S2Error({
+										message: "SSE stream closed with incomplete data remaining",
+										status: 502,
+										code: "STREAM_CLOSED_PREMATURELY",
+										origin: "sdk",
+									});
+								}
+								return downstream.close();
+							}
 							buffer = concatBuffer(buffer, chunk.value);
 							continue;
 						}

--- a/packages/streamstore/src/tests/event-stream.test.ts
+++ b/packages/streamstore/src/tests/event-stream.test.ts
@@ -153,22 +153,26 @@ describe("EventStream boundary detection (issue #118)", () => {
 			expect(results).toEqual(["line1\nline2"]);
 		});
 
-		it("text without any newlines produces no output", async () => {
+		it("errors when EOF leaves an incomplete message with no newline", async () => {
 			const raw = "data:incomplete";
 			const buf = encoder.encode(raw);
 			const body = streamFromBytes(buf);
 			const stream = new EventStream<string>(body, parseString);
-			const results = await collectStream(stream);
-			expect(results).toEqual([]);
+			await expect(collectStream(stream)).rejects.toMatchObject({
+				code: "STREAM_CLOSED_PREMATURELY",
+				status: 502,
+			});
 		});
 
-		it("single newline at end does not produce a split", async () => {
+		it("errors when EOF leaves a partially framed message", async () => {
 			const raw = "data:incomplete\n";
 			const buf = encoder.encode(raw);
 			const body = streamFromBytes(buf);
 			const stream = new EventStream<string>(body, parseString);
-			const results = await collectStream(stream);
-			expect(results).toEqual([]);
+			await expect(collectStream(stream)).rejects.toMatchObject({
+				code: "STREAM_CLOSED_PREMATURELY",
+				status: 502,
+			});
 		});
 	});
 
@@ -201,6 +205,23 @@ describe("EventStream boundary detection (issue #118)", () => {
 			const stream = new EventStream<string>(body, parseString);
 			const results = await collectStream(stream);
 			expect(results).toEqual(["slow"]);
+		});
+
+		it("does not silently drop buffered data when EOF cuts off a later message", async () => {
+			const first = encoder.encode("data:first\n\n");
+			const second = encoder.encode("data:second");
+			const body = streamFromChunks([first, second]);
+			const stream = new EventStream<string>(body, parseString);
+			const reader = stream.getReader();
+
+			await expect(reader.read()).resolves.toEqual({
+				done: false,
+				value: "first",
+			});
+			await expect(reader.read()).rejects.toMatchObject({
+				code: "STREAM_CLOSED_PREMATURELY",
+				status: 502,
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary
- treat fetch/SSE EOF with buffered but unframed data as `STREAM_CLOSED_PREMATURELY` instead of a clean close
- avoid silently ending `readSession` when the final SSE event is truncated after the server started sending it
- add parser regressions for incomplete EOF and for a later message cut off after an earlier message was delivered

## Testing
- `npx vitest run packages/streamstore/src/tests/event-stream.test.ts`
- `npx vitest run packages/streamstore/src/tests/retryReadSession.test.ts`