### PR TITLE
fix: cap declared frame size to prevent reader OOM from untrusted _frame_bytes (#230)

### DIFF
--- a/.changeset/fix-frame-bytes-oom.md
+++ b/.changeset/fix-frame-bytes-oom.md
@@ -1,0 +1,12 @@
+---
+"@s2-dev/streamstore-patterns": patch
+---
+
+fix: cap declared frame size to prevent reader OOM from untrusted `_frame_bytes` (#230)
+
+`FrameAssembler` allocated its reassembly buffer directly from the attacker-controlled
+`_frame_bytes` header, so a tiny record declaring a huge frame could force a reader to
+eagerly allocate that much memory. Frames whose declared size is non-positive or exceeds
+`maxFrameBytes` (default 100 MiB) are now dropped before allocating. The limit is
+configurable via `FrameAssembler`'s constructor and `DeserializingReadSession`'s
+`maxFrameBytes` option.

--- a/packages/patterns/src/patterns/framing.ts
+++ b/packages/patterns/src/patterns/framing.ts
@@ -69,12 +69,9 @@ export type CompletedFrame = {
 };
 
 /**
- * Default upper bound on a single frame's declared size (100 MiB).
- *
- * The `_frame_bytes` header is attacker-controlled: a tiny record can declare a
- * huge frame and force the reader to eagerly allocate that much memory. Frames
- * declaring more than this are dropped instead of allocated. Override via
- * {@link FrameAssemblerOptions.maxFrameBytes} when larger messages are expected.
+ * Default cap on a frame's declared size (100 MiB). `_frame_bytes` is
+ * attacker-controlled, so frames declaring more than this are dropped rather
+ * than allocated. Override via {@link FrameAssemblerOptions.maxFrameBytes}.
  */
 export const DEFAULT_MAX_FRAME_BYTES = 100 * 1024 * 1024;
 
@@ -112,8 +109,10 @@ export class FrameAssembler {
 				this.reset();
 			}
 			if (maybeMeta.bytes <= 0 || maybeMeta.bytes > this.maxFrameBytes) {
-				// Invalid or oversized declared frame size: drop it without
-				// allocating, so a malicious header can't exhaust reader memory.
+				// Drop without allocating, so a bad header can't exhaust memory.
+				console.error(
+					`FrameAssembler: dropping frame with invalid declared size ${maybeMeta.bytes} bytes (max ${this.maxFrameBytes})`,
+				);
 				return completed;
 			}
 			this.buffer = new Uint8Array(maybeMeta.bytes);

--- a/packages/patterns/src/patterns/framing.ts
+++ b/packages/patterns/src/patterns/framing.ts
@@ -69,6 +69,21 @@ export type CompletedFrame = {
 };
 
 /**
+ * Default upper bound on a single frame's declared size (100 MiB).
+ *
+ * The `_frame_bytes` header is attacker-controlled: a tiny record can declare a
+ * huge frame and force the reader to eagerly allocate that much memory. Frames
+ * declaring more than this are dropped instead of allocated. Override via
+ * {@link FrameAssemblerOptions.maxFrameBytes} when larger messages are expected.
+ */
+export const DEFAULT_MAX_FRAME_BYTES = 100 * 1024 * 1024;
+
+export type FrameAssemblerOptions = {
+	/** Maximum declared frame size to allocate. Defaults to {@link DEFAULT_MAX_FRAME_BYTES}. */
+	maxFrameBytes?: number;
+};
+
+/**
  * Stateful helper that consumes byte records and yields complete frames when
  * all pieces have been received.
  */
@@ -78,6 +93,11 @@ export class FrameAssembler {
 	private writtenBytes = 0;
 	private expectedBytes = 0;
 	private currentMeta: FrameMeta | undefined;
+	private readonly maxFrameBytes: number;
+
+	constructor(options?: FrameAssemblerOptions) {
+		this.maxFrameBytes = options?.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
+	}
 
 	push(record: ByteRecord): CompletedFrame[] {
 		const completed: CompletedFrame[] = [];
@@ -90,6 +110,11 @@ export class FrameAssembler {
 			if (this.buffer && this.buffer.length > 0) {
 				// Incomplete frame: drop existing buffered data on new frame boundary.
 				this.reset();
+			}
+			if (maybeMeta.bytes <= 0 || maybeMeta.bytes > this.maxFrameBytes) {
+				// Invalid or oversized declared frame size: drop it without
+				// allocating, so a malicious header can't exhaust reader memory.
+				return completed;
 			}
 			this.buffer = new Uint8Array(maybeMeta.bytes);
 			this.remainingRecords = maybeMeta.records;

--- a/packages/patterns/src/patterns/serialization.ts
+++ b/packages/patterns/src/patterns/serialization.ts
@@ -159,6 +159,12 @@ export class SerializingAppendSession<Message> extends WritableStream<Message> {
 
 export interface DeserializingReadSessionOptions {
 	enableDedupe?: boolean;
+	/**
+	 * Maximum declared frame size to allocate while reassembling messages.
+	 * Frames whose `_frame_bytes` header exceeds this are dropped instead of
+	 * allocated. Defaults to {@link DEFAULT_MAX_FRAME_BYTES} (100 MiB).
+	 */
+	maxFrameBytes?: number;
 }
 
 export class DeserializingReadSession<Message> extends ReadableStream<Message> {
@@ -170,7 +176,9 @@ export class DeserializingReadSession<Message> extends ReadableStream<Message> {
 		super({
 			start: async (controller) => {
 				const reader = session.getReader();
-				const assembler = new FrameAssembler();
+				const assembler = new FrameAssembler({
+					maxFrameBytes: options?.maxFrameBytes,
+				});
 				const dedupe = new DedupeFilter();
 
 				try {
@@ -237,7 +245,9 @@ export {
 } from "./dedupe.js";
 export {
 	type CompletedFrame,
+	DEFAULT_MAX_FRAME_BYTES,
 	FrameAssembler,
+	type FrameAssemblerOptions,
 	type FrameMeta,
 	frameChunksToRecords,
 } from "./framing.js";

--- a/packages/patterns/src/patterns/serialization.ts
+++ b/packages/patterns/src/patterns/serialization.ts
@@ -160,9 +160,8 @@ export class SerializingAppendSession<Message> extends WritableStream<Message> {
 export interface DeserializingReadSessionOptions {
 	enableDedupe?: boolean;
 	/**
-	 * Maximum declared frame size to allocate while reassembling messages.
-	 * Frames whose `_frame_bytes` header exceeds this are dropped instead of
-	 * allocated. Defaults to {@link DEFAULT_MAX_FRAME_BYTES} (100 MiB).
+	 * Max declared frame size to allocate. Frames exceeding this are dropped.
+	 * Defaults to {@link DEFAULT_MAX_FRAME_BYTES} (100 MiB).
 	 */
 	maxFrameBytes?: number;
 }

--- a/packages/patterns/src/tests/reproductions/issue-230.test.ts
+++ b/packages/patterns/src/tests/reproductions/issue-230.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_MAX_FRAME_BYTES,
 	FrameAssembler,
@@ -6,14 +6,9 @@ import {
 } from "../../patterns/framing.js";
 
 /**
- * Issue #230: Untrusted `_frame_bytes` header can trigger reader OOM.
- *
- * `FrameAssembler` sized its buffer directly from the attacker-controlled
- * `_frame_bytes` header (`new Uint8Array(maybeMeta.bytes)`), so a tiny record
- * declaring a huge frame forced the reader to eagerly allocate that much memory.
- *
- * The fix drops frames whose declared size is non-positive or exceeds
- * `maxFrameBytes` (default 100 MiB) before allocating.
+ * Issue #230: an untrusted `_frame_bytes` header could trigger reader OOM,
+ * since `FrameAssembler` sized its buffer straight from it. The fix drops
+ * frames whose declared size is non-positive or over `maxFrameBytes`.
  */
 
 function frameRecord(
@@ -28,6 +23,16 @@ function frameRecord(
 }
 
 describe("Issue #230: FrameAssembler rejects oversized declared frames", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("drops a frame declaring more than the default max without allocating", () => {
 		const assembler = new FrameAssembler();
 		// 54-byte record declaring a 100 MiB frame.
@@ -40,6 +45,9 @@ describe("Issue #230: FrameAssembler rejects oversized declared frames", () => {
 		expect(frames).toEqual([]);
 		const more = assembler.push({ body: new Uint8Array(4) });
 		expect(more).toEqual([]);
+
+		// The drop is logged, not silent.
+		expect(errorSpy).toHaveBeenCalledOnce();
 	});
 
 	it("drops a frame declaring zero bytes", () => {

--- a/packages/patterns/src/tests/reproductions/issue-230.test.ts
+++ b/packages/patterns/src/tests/reproductions/issue-230.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_MAX_FRAME_BYTES,
+	FrameAssembler,
+	makeFrameHeaders,
+} from "../../patterns/framing.js";
+
+/**
+ * Issue #230: Untrusted `_frame_bytes` header can trigger reader OOM.
+ *
+ * `FrameAssembler` sized its buffer directly from the attacker-controlled
+ * `_frame_bytes` header (`new Uint8Array(maybeMeta.bytes)`), so a tiny record
+ * declaring a huge frame forced the reader to eagerly allocate that much memory.
+ *
+ * The fix drops frames whose declared size is non-positive or exceeds
+ * `maxFrameBytes` (default 100 MiB) before allocating.
+ */
+
+function frameRecord(
+	declaredBytes: number,
+	numRecords: number,
+	body: Uint8Array,
+) {
+	return {
+		headers: makeFrameHeaders(declaredBytes, numRecords) as any,
+		body,
+	};
+}
+
+describe("Issue #230: FrameAssembler rejects oversized declared frames", () => {
+	it("drops a frame declaring more than the default max without allocating", () => {
+		const assembler = new FrameAssembler();
+		// 54-byte record declaring a 100 MiB frame.
+		const frames = assembler.push(
+			frameRecord(DEFAULT_MAX_FRAME_BYTES + 1, 1, new Uint8Array(4)),
+		);
+
+		// Frame is dropped: nothing completes, and no buffer was retained for the
+		// follow-up body record to write into.
+		expect(frames).toEqual([]);
+		const more = assembler.push({ body: new Uint8Array(4) });
+		expect(more).toEqual([]);
+	});
+
+	it("drops a frame declaring zero bytes", () => {
+		const assembler = new FrameAssembler();
+		expect(assembler.push(frameRecord(0, 1, new Uint8Array(0)))).toEqual([]);
+	});
+
+	it("still assembles a valid frame within the limit", () => {
+		const assembler = new FrameAssembler();
+		const payload = new TextEncoder().encode("hello");
+		const frames = assembler.push(frameRecord(payload.length, 1, payload));
+		expect(frames).toHaveLength(1);
+		expect(frames[0]!.payload).toEqual(payload);
+	});
+
+	it("honors a custom maxFrameBytes", () => {
+		const assembler = new FrameAssembler({ maxFrameBytes: 8 });
+		// Over the custom limit -> dropped.
+		expect(assembler.push(frameRecord(9, 1, new Uint8Array(4)))).toEqual([]);
+
+		// Within the custom limit -> assembled.
+		const payload = new Uint8Array([1, 2, 3, 4]);
+		const frames = assembler.push(frameRecord(4, 1, payload));
+		expect(frames).toHaveLength(1);
+		expect(frames[0]!.payload).toEqual(payload);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #230.

`FrameAssembler` (in `@s2-dev/streamstore-patterns`) sized its reassembly buffer directly from the `_frame_bytes` header — `new Uint8Array(maybeMeta.bytes)` — which is attacker-controlled. A tiny record declaring a huge frame forced the reader to eagerly allocate that much memory: a 54-byte record with `_frame_bytes: 104857600` causes a 100 MiB allocation (~1.9M× amplification). This bypasses the per-record/append size limits, which validate the *wire* size, not the *declared* frame size.

## Fix

Validate the declared size before allocating. Frames with `bytes <= 0` or `bytes > maxFrameBytes` are dropped without allocating:

```ts
if (maybeMeta.bytes <= 0 || maybeMeta.bytes > this.maxFrameBytes) {
  return completed; // drop; don't allocate
}
this.buffer = new Uint8Array(maybeMeta.bytes);
```

- `maxFrameBytes` defaults to `DEFAULT_MAX_FRAME_BYTES` (100 MiB) and is configurable via the `FrameAssembler` constructor and `DeserializingReadSession`'s new `maxFrameBytes` option.
- The `bytes <= 0` guard is safe: a legitimately framed message always declares `bytes > 0` (`frameChunksToRecords([])` returns `[]`, so empty messages never produce a frame).

## Test

`src/tests/reproductions/issue-230.test.ts` covers: oversized frame dropped without retaining a buffer, zero-byte frame dropped, a valid in-limit frame still assembles, and a custom `maxFrameBytes` boundary. Verified the oversized/zero-byte cases fail without the fix and pass with it.

## Verification

- New test: oversized/zero-byte cases fail pre-fix, all pass post-fix
- Patterns suite: 21/21 pass
- `bun run check` (biome + tsc + build across all packages): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)