### PR TITLE
fix: validate seq_num_mismatch against MAX_SAFE_INTEGER (#233)

### DIFF
--- a/.changeset/fix-seqnum-mismatch-unsafe-integer.md
+++ b/.changeset/fix-seqnum-mismatch-unsafe-integer.md
@@ -1,0 +1,10 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+fix: append precondition errors no longer return a corrupted expected sequence number (#233)
+
+`makeAppendPreconditionError` converted `seq_num_mismatch` with `Number(...)` and no
+validation, so a value beyond `Number.MAX_SAFE_INTEGER` produced a corrupted
+`expectedSeqNum`. It now throws an `S2Error` with code `UNSAFE_INTEGER` in that case,
+matching the success-path guard (`bigintToSafeNumber`).

--- a/packages/streamstore/src/error.ts
+++ b/packages/streamstore/src/error.ts
@@ -462,6 +462,15 @@ export function makeAppendPreconditionError(
 	if (json && typeof json === "object") {
 		if ("seq_num_mismatch" in json) {
 			const expected = Number(json.seq_num_mismatch);
+			// Don't hand back a sequence number that lost precision.
+			if (!Number.isSafeInteger(expected)) {
+				throw new S2Error({
+					message: `seq_num_mismatch exceeds JavaScript Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); use protobuf transport with bigint support or ensure values stay within 53-bit range`,
+					code: "UNSAFE_INTEGER",
+					status: 0,
+					origin: "sdk",
+				});
+			}
 			return new SeqNumMismatchError({
 				message: "Append condition failed: sequence number mismatch",
 				code: "APPEND_CONDITION_FAILED",


### PR DESCRIPTION
## Summary

Fixes #233.

`makeAppendPreconditionError` (412 handler) converted `seq_num_mismatch` with `Number(json.seq_num_mismatch)` and no validation, so a value beyond `Number.MAX_SAFE_INTEGER` produced a corrupted `expectedSeqNum`. That silently breaks the documented contract (the actual next sequence number) and can trap callers retrying against a wrong value.

The success path already guards every u64→number conversion via `bigintToSafeNumber`, which throws `S2Error{ code: "UNSAFE_INTEGER" }`. The error path bypassed that. This makes the two consistent.

## Fix

In the `seq_num_mismatch` branch, throw `UNSAFE_INTEGER` (same message/shape/origin as `bigintToSafeNumber`) when the parsed value isn't a safe integer, instead of returning it:

```ts
const expected = Number(json.seq_num_mismatch);
if (!Number.isSafeInteger(expected)) {
  throw new S2Error({ /* ... */ code: "UNSAFE_INTEGER", status: 0, origin: "sdk" });
}
```

`Number.isSafeInteger` correctly flags both the JSON-number case (precision already lost at parse → value ≥ 2^53 fails the check) and any non-numeric case (`NaN` fails). `bigintToSafeNumber` couldn't be reused directly without an `error.ts`→`proto.ts` circular import, so the guard is inline.

Only triggers above 2^53 (~9 quadrillion records), so it's rare — but it closes the asymmetry with the success path. The `fencing_token_mismatch` branch is unaffected (it's a string).

## Verification

- `bun run check` (biome + tsc + build): clean
- streamstore unit suite: 398/398 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)