### PR TITLE
fix: don't send metrics path params in the query string (#235)

### DIFF
--- a/.changeset/fix-metrics-path-params-in-query.md
+++ b/.changeset/fix-metrics-path-params-in-query.md
@@ -1,0 +1,10 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+fix: metrics `basin()`/`stream()` no longer send path params in the query string (#235)
+
+Both methods spread `...args` into the request `query`, so `basin` (and `stream`) were
+serialized into the URL query string in addition to the path. They now pass `path` and
+`query` explicitly — only `{ basin }` / `{ basin, stream }` in the path and only
+`set/start/end/interval` in the query — matching the OpenAPI spec and the Go and Python SDKs.

--- a/packages/streamstore/src/metrics.ts
+++ b/packages/streamstore/src/metrics.ts
@@ -118,11 +118,12 @@ export class S2Metrics {
 			return await withS2Data(() =>
 				basinMetrics({
 					client: this.client,
-					path: args,
+					path: { basin: args.basin },
 					query: toSnakeCase({
-						...args,
+						set: args.set,
 						start: toEpochSeconds(args.start),
 						end: toEpochSeconds(args.end),
+						interval: args.interval,
 					}),
 					...options,
 				}),
@@ -149,11 +150,12 @@ export class S2Metrics {
 			return await withS2Data(() =>
 				streamMetrics({
 					client: this.client,
-					path: args,
+					path: { basin: args.basin, stream: args.stream },
 					query: toSnakeCase({
-						...args,
+						set: args.set,
 						start: toEpochSeconds(args.start),
 						end: toEpochSeconds(args.end),
+						interval: args.interval,
 					}),
 					...options,
 				}),


### PR DESCRIPTION
## Summary

Fixes #235.

`S2Metrics.basin()` and `.stream()` passed `path: args` **and** `query: toSnakeCase({ ...args, ... })`. The `...args` spread includes the path params, so `basin` (and `stream`) were serialized into the URL query string on every metrics call — e.g. `GET /metrics/{basin}?set=…&basin=…`. This violates the generated type contract and the OpenAPI spec.

Impact today is benign — the OSS server's query struct has no `deny_unknown_fields` and axum's `Query` ignores unknown params, so the redundant params are dropped server-side. But it's live wrong behavior on every request and would break if query validation ever tightened.

## Fix

Pass `path` and `query` explicitly:

```ts
basinMetrics({
  client: this.client,
  path: { basin: args.basin },
  query: toSnakeCase({ set: args.set, start: toEpochSeconds(args.start), end: toEpochSeconds(args.end), interval: args.interval }),
  ...options,
});
```

(and `{ basin, stream }` for `stream()`). `account()` is unchanged — it has no path params, so its `...args`→query was already correct.

## Cross-SDK verification

The path-only placement is unanimous across the spec and the other SDKs; TS was the sole outlier:

| Source | basin/stream | query |
|--------|--------------|-------|
| OSS `openapi.json` | `in: path` | `set, start, end, interval` |
| Python (`_ops.py`) | URL path `/v1/metrics/{basin}[/{stream}]` | `set, start, end, interval` |
| Go (`metrics.go`) | URL path `/metrics/%s[/%s]` | `set, start, end, interval` |
| TS (this PR) | `path: {basin[, stream]}` | `set, start, end, interval` |

## Verification

- `bun run check` (biome + tsc + build): clean
- streamstore unit suite: 398/398 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)