### PR TITLE
fix: make persistToS2 onSeqNumMismatch callback actually fire (#248)

### DIFF
--- a/.changeset/fix-seqnum-mismatch-callback.md
+++ b/.changeset/fix-seqnum-mismatch-callback.md
@@ -1,0 +1,13 @@
+---
+"@s2-dev/resumable-stream": patch
+---
+
+fix: `persistToS2` now actually invokes `onSeqNumMismatch` (#248)
+
+The per-record `instanceof SeqNumMismatchError` check was unreachable — `Producer.submit()`
+wraps a pump failure in a generic `S2Error`, so the callback never fired. The genuine
+`SeqNumMismatchError` surfaces from `producer.close()`, so the handling now runs after the
+producer is closed: when the persist failure is (or contains) a `SeqNumMismatchError` and an
+`onSeqNumMismatch` callback was provided, it's invoked and treated as an expected
+fenced/concurrent-writer condition instead of being thrown. Callers without the callback are
+unaffected (the failure still throws).

--- a/packages/resumable-stream/src/protocol.ts
+++ b/packages/resumable-stream/src/protocol.ts
@@ -104,6 +104,22 @@ function combineErrors(errors: ReadonlyArray<unknown>): unknown | undefined {
 	);
 }
 
+/**
+ * Locate a {@link SeqNumMismatchError} in a persist failure. A mismatch is a
+ * terminal pump error, so it surfaces from `producer.close()` and may be
+ * combined with the generic "producer has failed" error that later `submit()`
+ * calls throw — hence the `AggregateError` case.
+ */
+function findSeqNumMismatch(failure: unknown): SeqNumMismatchError | undefined {
+	if (failure instanceof SeqNumMismatchError) return failure;
+	if (failure instanceof AggregateError) {
+		for (const error of failure.errors) {
+			if (error instanceof SeqNumMismatchError) return error;
+		}
+	}
+	return undefined;
+}
+
 export async function persistToS2<T>({
 	s2,
 	basin,
@@ -131,13 +147,7 @@ export async function persistToS2<T>({
 		let sourceError: unknown | undefined;
 		try {
 			for await (const value of source) {
-				await producer.submit(toRecord(value)).catch((err: unknown) => {
-					if (err instanceof SeqNumMismatchError) {
-						onSeqNumMismatch?.(err);
-						return;
-					}
-					throw err;
-				});
+				await producer.submit(toRecord(value));
 			}
 		} catch (err) {
 			sourceError = err;
@@ -161,6 +171,13 @@ export async function persistToS2<T>({
 
 		const failure = combineErrors([sourceError, finalizationError, closeError]);
 		if (failure !== undefined) {
+			// A seq-num mismatch means another writer fenced/advanced this stream;
+			// treat it as an expected, handled condition rather than an error.
+			const mismatch = findSeqNumMismatch(failure);
+			if (mismatch && onSeqNumMismatch) {
+				onSeqNumMismatch(mismatch);
+				return;
+			}
 			throw failure;
 		}
 	} finally {


### PR DESCRIPTION
## Summary

Fixes #248.

`persistToS2`'s `onSeqNumMismatch` callback was dead code. The per-record handler checked `err instanceof SeqNumMismatchError`, but `Producer.submit()` wraps a pump failure in a **generic** `S2Error` (`producer.ts:361`), so the check was never true and the callback never fired. The handler was also conceptually wrong at the per-record level: a seq-num mismatch is a *terminal* pump error, so the producer is dead afterward and "skip this record and continue" can't work.

## Fix

- Removed the unreachable per-record `.catch` branch (`await producer.submit(toRecord(value))`).
- The genuine `SeqNumMismatchError` surfaces from `producer.close()`, which rethrows the original `pumpError` unwrapped. So the handling now runs after the producer is closed: `findSeqNumMismatch(failure)` looks for it both directly and inside the `AggregateError` (a later `submit()` may also have logged the generic wrapper into `sourceError`). When found **and** a callback was provided, invoke it and return — treating a fenced/concurrent-writer mismatch as an expected, handled condition rather than throwing.

## Scope / safety

- Behavior only changes for callers that opt in by providing `onSeqNumMismatch` (today: `index.ts`, which wants exactly this graceful handling).
- `adapter.ts` doesn't pass the callback, so its mismatch still throws — unchanged.

## Verification

- `bun run check` (biome + tsc + build): clean
- resumable-stream unit suite: 51/51 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)