### PR TITLE
fix: yield terminal chunk on 204 replay so TanStack chat doesn't hang (#250)

### DIFF
--- a/.changeset/fix-tanstack-204-hang.md
+++ b/.changeset/fix-tanstack-204-hang.md
@@ -1,0 +1,10 @@
+---
+"@s2-dev/resumable-stream": patch
+---
+
+fix: TanStack AI chat no longer hangs when the replay endpoint returns HTTP 204 (#250)
+
+`subscribeChunks` returned an empty stream on a 204/no-body replay response, so
+TanStack's subscription loop ended without a terminal chunk and `streamResponse()`
+hung forever on `processingComplete`. It now yields a synthetic `RUN_FINISHED` so
+the subscription terminates cleanly. This restores the behavior dropped in #241.

--- a/packages/resumable-stream/README.md
+++ b/packages/resumable-stream/README.md
@@ -308,6 +308,9 @@ export async function GET(req: Request) {
     fromSeqNum: url.searchParams.has("from")
       ? Number(url.searchParams.get("from"))
       : undefined,
+    // Pass `live` through so the client's `&live=1` keeps the SSE open at the
+    // tail; without it an idle replay returns 204.
+    live: url.searchParams.get("live") === "1",
   });
 }
 ```

--- a/packages/resumable-stream/src/tanstack-ai/client.ts
+++ b/packages/resumable-stream/src/tanstack-ai/client.ts
@@ -133,6 +133,12 @@ async function* subscribeChunks(
 		}
 
 		if (response.status === 204 || !response.body) {
+			// A 204 means there is nothing (more) to replay, so it is terminal
+			// even when `reconnectBackoffMs` is set: retrying would busy-loop on
+			// a genuinely idle replay. Yield a synthetic terminal chunk so
+			// TanStack's `processingComplete` resolves instead of hanging. (Live
+			// setups should forward `live` to the replay so it streams rather
+			// than returning 204 in the first place.)
 			yield makeSyntheticRunFinished();
 			return;
 		}

--- a/packages/resumable-stream/src/tanstack-ai/client.ts
+++ b/packages/resumable-stream/src/tanstack-ai/client.ts
@@ -49,6 +49,23 @@ export interface ConnectionOptions {
 	reconnectBackoffMs?: readonly number[];
 }
 
+/**
+ * Terminal chunk yielded when a replay response has no body (HTTP 204).
+ *
+ * TanStack waits for a terminal chunk after `send()`; a 204 means there is
+ * nothing active to replay, so without this the subscription ends empty and
+ * `streamResponse()` hangs on `await processingComplete`.
+ */
+function makeSyntheticRunFinished(): StreamChunk {
+	return {
+		type: "RUN_FINISHED",
+		threadId: "s2-replay",
+		runId: `s2-replay-${Date.now()}`,
+		timestamp: Date.now(),
+		finishReason: "stop",
+	} as StreamChunk;
+}
+
 function sleepAbortable(ms: number, signal: AbortSignal): Promise<void> {
 	if (ms <= 0 || signal.aborted) return Promise.resolve();
 	return new Promise<void>((resolve) => {
@@ -115,7 +132,10 @@ async function* subscribeChunks(
 			continue;
 		}
 
-		if (response.status === 204 || !response.body) return;
+		if (response.status === 204 || !response.body) {
+			yield makeSyntheticRunFinished();
+			return;
+		}
 
 		try {
 			for await (const frame of pipeSseFrames(response.body, signal)) {

--- a/packages/resumable-stream/src/tests/reproductions/issue-250.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-250.test.ts
@@ -1,0 +1,52 @@
+import type { StreamChunk } from "@tanstack/ai";
+import { describe, expect, it } from "vitest";
+import { createConnection } from "../../tanstack-ai/client.js";
+
+/**
+ * Issue #250: TanStack AI chat streaming hangs when replay returns HTTP 204.
+ *
+ * `subscribeChunks` returned an empty `AsyncIterable` on a 204/no-body replay
+ * response, so TanStack's `consumeSubscription` loop finished without ever
+ * seeing a terminal chunk and `streamResponse()` hung on `processingComplete`.
+ * The fix yields a synthetic `RUN_FINISHED` so the subscription terminates.
+ */
+
+async function drain(
+	iterable: AsyncIterable<StreamChunk>,
+): Promise<StreamChunk[]> {
+	const out: StreamChunk[] = [];
+	for await (const chunk of iterable) out.push(chunk);
+	return out;
+}
+
+describe("Issue #250: 204 replay yields a terminal chunk", () => {
+	it("yields a synthetic RUN_FINISHED instead of an empty stream on 204", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(null, { status: 204 });
+		const connection = createConnection({
+			sendUrl: "/api/chat",
+			subscribeUrl: "/api/chat/stream",
+			fetch,
+		});
+
+		const collected = await drain(connection.subscribe());
+
+		expect(collected).toHaveLength(1);
+		expect(collected[0]!.type).toBe("RUN_FINISHED");
+	});
+
+	it("also terminates when the response has a 200 status but no body", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(null, { status: 200 });
+		const connection = createConnection({
+			sendUrl: "/api/chat",
+			subscribeUrl: "/api/chat/stream",
+			fetch,
+		});
+
+		const collected = await drain(connection.subscribe());
+
+		expect(collected).toHaveLength(1);
+		expect(collected[0]!.type).toBe("RUN_FINISHED");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #250.

`subscribeChunks` in `@s2-dev/resumable-stream`'s TanStack AI client returned an empty `AsyncIterable` on a 204 / no-body replay response. TanStack's `consumeSubscription` loop then ended without ever seeing a terminal chunk, so `resolveProcessing()` never fired and `ChatClient.streamResponse()` hung forever on `await processingComplete`.

This is a regression: #214 added `makeSyntheticRunFinished()` specifically for the 204 case, and the #241 "simplify" refactor dropped it while keeping the generator-based subscription.

## Verification of the hang (against the installed `@tanstack/ai-client`)

- `consumeSubscription` only calls `resolveProcessing()` from inside its `for await` loop, on a `RUN_FINISHED`/`RUN_ERROR` chunk — an empty stream never enters the loop body.
- `startSubscription` only resolves via its `.catch()`, which doesn't fire on a clean, error-free empty completion.
- The processor tolerates a standalone synthetic `RUN_FINISHED` (`handleRunFinishedEvent` deletes from an already-empty `activeRuns` set and finalizes cleanly — no preceding `RUN_STARTED` needed).

## Fix

- Yield a synthetic `RUN_FINISHED` before returning on 204/no-body, so the subscription terminates and `processingComplete` resolves.
- README: the replay `GET` handler now forwards `live`, matching the client's `&live=1` — otherwise an idle replay returns 204 in the first place (the root trigger).

## Test

- Full `resumable-stream` suite: 53 pass / 17 e2e skipped.
- `bun run check` (biome + tsc + build + attw): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)