### PR TITLE
fix: reconnect subscribeSse on mid-stream errors instead of crashing (#249)

### DIFF
--- a/.changeset/fix-subscribesse-reconnect-on-error.md
+++ b/.changeset/fix-subscribesse-reconnect-on-error.md
@@ -1,0 +1,12 @@
+---
+"@s2-dev/resumable-stream": patch
+---
+
+fix: SSE subscriptions reconnect on mid-stream errors instead of crashing (#249)
+
+`subscribeSse` only wrapped the `fetchOk` call in try/catch, not the `for await`
+over `pipeSseFrames`. When the response body errored mid-iteration, the throw
+escaped before the reconnection logic could run, so the subscription crashed with
+no recovery. The loop is now wrapped: it reconnects from the last cursor when
+`reconnectBackoffMs` is set and rethrows when reconnect is disabled, matching the
+TanStack `subscribeChunks` path. This restores behavior dropped in #241.

--- a/packages/resumable-stream/src/client-utils.ts
+++ b/packages/resumable-stream/src/client-utils.ts
@@ -226,22 +226,30 @@ export async function* subscribeSse<T>(
 
 		if (response.status === 204 || !response.body) return;
 
-		for await (const frame of pipeSseFrames(response.body, signal)) {
-			if (frame.id) {
-				const parsed = Number.parseInt(frame.id, 10);
-				if (
-					Number.isSafeInteger(parsed) &&
-					parsed >= 0 &&
-					(cursor === undefined || parsed > cursor)
-				) {
-					cursor = parsed;
+		try {
+			for await (const frame of pipeSseFrames(response.body, signal)) {
+				if (frame.id) {
+					const parsed = Number.parseInt(frame.id, 10);
+					if (
+						Number.isSafeInteger(parsed) &&
+						parsed >= 0 &&
+						(cursor === undefined || parsed > cursor)
+					) {
+						cursor = parsed;
+					}
 				}
+				if (!frame.data) continue;
+				attempt = 0;
+				try {
+					yield JSON.parse(frame.data) as T;
+				} catch {}
 			}
-			if (!frame.data) continue;
-			attempt = 0;
-			try {
-				yield JSON.parse(frame.data) as T;
-			} catch {}
+		} catch (err) {
+			// A mid-stream error (e.g. the body drops) is recoverable: fall
+			// through to reconnect from the last cursor unless aborted, or
+			// rethrow when reconnect is disabled.
+			if (signal.aborted) return;
+			if (backoffMs.length === 0) throw err;
 		}
 
 		if (signal.aborted) return;

--- a/packages/resumable-stream/src/tests/reproductions/issue-249.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-249.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { subscribeSse } from "../../client-utils.js";
+
+/**
+ * Issue #249: SSE client subscriptions crash on mid-stream errors instead of
+ * reconnecting.
+ *
+ * `subscribeSse` wrapped only the `fetchOk` call in try/catch, not the
+ * `for await` over `pipeSseFrames`. When the response body errored
+ * mid-iteration, the throw escaped the function before it could reach the
+ * reconnection logic. The fix wraps the loop: it reconnects from the last
+ * cursor when backoff is configured, and rethrows when it is disabled.
+ */
+
+function sseFrame(id: number, data: unknown): string {
+	return `id: ${id}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** A body that yields `prefix`, then errors mid-stream. */
+function erroringBody(prefix: string): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	let sent = false;
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (!sent) {
+				sent = true;
+				controller.enqueue(encoder.encode(prefix));
+				return;
+			}
+			controller.error(new Error("Network failure during pull"));
+		},
+	});
+}
+
+function sseResponse(body: BodyInit | null, status = 200): Response {
+	return new Response(body, {
+		status,
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+
+async function collect<T>(
+	iterable: AsyncIterable<T>,
+	limit: number,
+): Promise<T[]> {
+	const out: T[] = [];
+	for await (const item of iterable) {
+		out.push(item);
+		if (out.length >= limit) break;
+	}
+	return out;
+}
+
+describe("Issue #249: subscribeSse recovers from mid-stream errors", () => {
+	it("reconnects from the last cursor when the stream errors mid-iteration", async () => {
+		const responses = [
+			sseResponse(erroringBody(sseFrame(1, { n: 1 }))),
+			sseResponse(sseFrame(2, { n: 2 })),
+		];
+		const urls: string[] = [];
+		const fetch: typeof globalThis.fetch = async (input) => {
+			urls.push(typeof input === "string" ? input : input.toString());
+			const next = responses.shift();
+			if (!next) throw new Error("unexpected extra fetch");
+			return next;
+		};
+
+		const got = await collect(
+			subscribeSse<{ n: number }>({
+				url: "/replay",
+				fetch,
+				reconnectBackoffMs: [0],
+			}),
+			2,
+		);
+
+		expect(got).toEqual([{ n: 1 }, { n: 2 }]);
+		// Reconnect resumed from the cursor advanced by frame id 1.
+		expect(urls[1]).toBe("/replay?from=1");
+	});
+
+	it("rethrows the mid-stream error when reconnect is disabled", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			sseResponse(erroringBody(sseFrame(1, { n: 1 })));
+
+		const iter = subscribeSse<{ n: number }>({
+			url: "/replay",
+			fetch,
+			reconnectBackoffMs: [],
+		});
+
+		await expect(collect(iter, 5)).rejects.toThrow(
+			"Network failure during pull",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #249.

`subscribeSse` in `@s2-dev/resumable-stream` wrapped only the `fetchOk` call in try/catch, not the `for await` over `pipeSseFrames`. When the response body errored mid-iteration (e.g. the underlying `ReadableStream` calls `controller.error()` or `pull()` throws), the error escaped the generator before the reconnection logic could run, so the subscription crashed with no automatic recovery.

This is a regression from the #241 "simplify" refactor: the sibling `subscribeChunks` (TanStack client) still wraps its loop correctly, and the pre-refactor flow caught body-drain errors and fell through to reconnect.

## Fix

Wrap the `for await` loop in try/catch, matching `subscribeChunks`:
- `return` if the signal is aborted,
- rethrow if `reconnectBackoffMs` is empty (reconnect disabled),
- otherwise fall through to the existing reconnect path, which resumes from the last cursor.

## Test

`reproductions/issue-249.test.ts`:
- reconnects from the last cursor when the stream errors mid-iteration (verified it resumes at `?from=1`),
- rethrows the mid-stream error when reconnect is disabled.

Confirmed the reconnect case fails without the fix and passes with it.

- Full `resumable-stream` suite: 55 pass / 17 e2e skipped.
- `bun run check` (biome + tsc + build + attw): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)