### PR TITLE
fix: resolve Detail bugs #234, #236, #237 

### DIFF
--- a/packages/resumable-stream/src/client-utils.ts
+++ b/packages/resumable-stream/src/client-utils.ts
@@ -77,7 +77,8 @@ export interface ParsedSseFrame {
 
 /**
  * Pipe a fetch response body through SSE parsing and yield raw frames. Cancels
- * the reader when `abortSignal` fires so the upstream fetch is freed promptly.
+ * the reader when `abortSignal` fires, and on any other early termination
+ * (consumer `break`/`return`/throw), so the upstream fetch is freed promptly.
  */
 export async function* pipeSseFrames(
 	body: ReadableStream<Uint8Array>,
@@ -101,6 +102,9 @@ export async function* pipeSseFrames(
 		}
 	} finally {
 		abortSignal?.removeEventListener("abort", cancel);
+		// Cancel (not just release) so early termination without an abort
+		// signal closes the fetch body.
+		await reader.cancel().catch(() => {});
 		reader.releaseLock();
 	}
 }

--- a/packages/resumable-stream/src/index.ts
+++ b/packages/resumable-stream/src/index.ts
@@ -132,7 +132,6 @@ export async function createResumableStream(
 	const { accessToken, basin, batchSize, lingerDuration, endpoints } =
 		getS2Config();
 	const s2 = new S2({ accessToken, endpoints });
-	const [persistentStream, clientStream] = makeStream().tee();
 	const sessionFencingToken = "session-" + generateFencingToken();
 
 	try {
@@ -176,6 +175,10 @@ export async function createResumableStream(
 		debugLog("Error initializing stream:", error);
 		return null;
 	}
+
+	// Created only after validation so the early returns above don't leak
+	// the teed branches.
+	const [persistentStream, clientStream] = makeStream().tee();
 
 	const persistStream = async () => {
 		try {

--- a/packages/resumable-stream/src/protocol.ts
+++ b/packages/resumable-stream/src/protocol.ts
@@ -95,7 +95,8 @@ export interface PersistToS2Options<T> {
 }
 
 function combineErrors(errors: ReadonlyArray<unknown>): unknown | undefined {
-	const failures = errors.filter((error) => error !== undefined);
+	// Dedupe by identity: a terminal pump error surfaces from multiple phases.
+	const failures = [...new Set(errors.filter((error) => error !== undefined))];
 	if (failures.length === 0) return undefined;
 	if (failures.length === 1) return failures[0];
 	return new AggregateError(
@@ -107,8 +108,8 @@ function combineErrors(errors: ReadonlyArray<unknown>): unknown | undefined {
 /**
  * Locate a {@link SeqNumMismatchError} in a persist failure. A mismatch is a
  * terminal pump error, so it surfaces from `producer.close()` and may be
- * combined with the generic "producer has failed" error that later `submit()`
- * calls throw — hence the `AggregateError` case.
+ * combined with distinct errors from other phases (e.g. a source failure) —
+ * hence the `AggregateError` case.
  */
 function findSeqNumMismatch(failure: unknown): SeqNumMismatchError | undefined {
 	if (failure instanceof SeqNumMismatchError) return failure;

--- a/packages/resumable-stream/src/tests/reproductions/issue-234.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-234.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { pipeSseFrames } from "../../client-utils.js";
+
+/**
+ * Issue #234: when the consumer stopped iterating without an abort signal,
+ * `pipeSseFrames` only released the reader lock, leaving the fetch body (and
+ * the connection) open. The fix cancels the reader on early termination.
+ */
+
+function sseFrame(id: number, data: string): string {
+	return `id: ${id}\ndata: ${data}\n\n`;
+}
+
+/** An endless SSE body that records whether it was canceled. */
+function endlessBody(): {
+	body: ReadableStream<Uint8Array>;
+	wasCancelled: () => boolean;
+} {
+	const encoder = new TextEncoder();
+	let cancelled = false;
+	let nextId = 1;
+	const body = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			controller.enqueue(encoder.encode(sseFrame(nextId, `chunk-${nextId}`)));
+			nextId += 1;
+		},
+		cancel() {
+			cancelled = true;
+		},
+	});
+	return { body, wasCancelled: () => cancelled };
+}
+
+describe("Issue #234: pipeSseFrames cancels the body on early termination", () => {
+	it("cancels the source body when the consumer breaks without an abort signal", async () => {
+		const { body, wasCancelled } = endlessBody();
+
+		for await (const frame of pipeSseFrames(body)) {
+			expect(frame.data).toBe("chunk-1");
+			break;
+		}
+
+		// Cancellation propagates through the pipeThrough chain asynchronously.
+		await vi.waitFor(() => {
+			expect(wasCancelled()).toBe(true);
+		});
+	});
+
+	it("cancels the source body when the consumer throws mid-iteration", async () => {
+		const { body, wasCancelled } = endlessBody();
+
+		await expect(
+			(async () => {
+				for await (const _frame of pipeSseFrames(body)) {
+					throw new Error("consumer failure");
+				}
+			})(),
+		).rejects.toThrow("consumer failure");
+
+		await vi.waitFor(() => {
+			expect(wasCancelled()).toBe(true);
+		});
+	});
+
+	it("still cancels via the abort signal", async () => {
+		const { body, wasCancelled } = endlessBody();
+		const controller = new AbortController();
+
+		for await (const _frame of pipeSseFrames(body, controller.signal)) {
+			controller.abort();
+		}
+
+		await vi.waitFor(() => {
+			expect(wasCancelled()).toBe(true);
+		});
+	});
+
+	it("consumes a finite body to completion without error", async () => {
+		const encoder = new TextEncoder();
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sseFrame(1, "a")));
+				controller.enqueue(encoder.encode(sseFrame(2, "b")));
+				controller.close();
+			},
+		});
+
+		const got: string[] = [];
+		for await (const frame of pipeSseFrames(body)) {
+			got.push(frame.data);
+		}
+		expect(got).toEqual(["a", "b"]);
+	});
+});

--- a/packages/resumable-stream/src/tests/reproductions/issue-236.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-236.test.ts
@@ -1,0 +1,76 @@
+import type { S2 } from "@s2-dev/streamstore";
+import { AppendRecord, FencingTokenMismatchError } from "@s2-dev/streamstore";
+import { describe, expect, it } from "vitest";
+import { persistToS2 } from "../../protocol.js";
+
+/**
+ * Issue #236: a takeover mid-persist surfaced as
+ * AggregateError([S2Error, FencingTokenMismatchError]) because submit()
+ * wrapped the pump error, failing the adapter's takeover check. After the
+ * fix, every phase surfaces the original error and the failure stays
+ * classifiable.
+ */
+
+/** A fake S2 whose append sessions always reject with the given error. */
+function makeFencedS2(error: FencingTokenMismatchError): S2 {
+	const session = {
+		readable: new ReadableStream(),
+		writable: new WritableStream(),
+		submit: () => Promise.reject(error),
+		close: () => Promise.resolve(),
+		acks: () => new ReadableStream(),
+		lastAckedPosition: () => undefined,
+		failureCause: () => undefined,
+		[Symbol.asyncDispose]: () => Promise.resolve(),
+	};
+	const handle = {
+		appendSession: () => Promise.resolve(session),
+		close: () => Promise.resolve(),
+	};
+	return {
+		basin: () => ({ stream: () => handle }),
+	} as unknown as S2;
+}
+
+async function* source(values: string[]): AsyncIterable<string> {
+	for (const value of values) {
+		yield value;
+		// Give the pump a chance to observe the rejection between submits.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+describe("Issue #236: persist failure during takeover stays classifiable", () => {
+	it("rejects with the original FencingTokenMismatchError, not a mixed aggregate", async () => {
+		const fencing = new FencingTokenMismatchError({
+			message: "fencing token mismatch",
+			expectedFencingToken: "other-writer",
+		});
+
+		const failure = await persistToS2({
+			s2: makeFencedS2(fencing),
+			basin: "test-basin",
+			stream: "test-stream",
+			source: source(["a", "b", "c"]),
+			fencingToken: "session-original",
+			batchSize: 1,
+			lingerDuration: 0,
+			toRecord: (value) => AppendRecord.string({ body: value }),
+			finalRecords: () => [AppendRecord.fence("end-test")],
+		}).then(
+			() => undefined,
+			(err: unknown) => err,
+		);
+
+		expect(failure).toBeDefined();
+		// The adapter's takeover check.
+		const isTakeover =
+			failure instanceof FencingTokenMismatchError ||
+			(failure instanceof AggregateError &&
+				failure.errors.length > 0 &&
+				failure.errors.every(
+					(error) => error instanceof FencingTokenMismatchError,
+				));
+		expect(isTakeover).toBe(true);
+	});
+});

--- a/packages/resumable-stream/src/tests/reproductions/issue-237.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-237.test.ts
@@ -1,0 +1,183 @@
+import {
+	FencingTokenMismatchError,
+	RangeNotSatisfiableError,
+} from "@s2-dev/streamstore";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #237: `createResumableStream` called `makeStream().tee()` before
+ * validation, leaking both teed branches on every early return. After the
+ * fix, the caller's stream is only created once validation succeeds.
+ */
+
+const mock = vi.hoisted(() => ({
+	handle: {} as Record<string, unknown>,
+}));
+
+vi.mock("@s2-dev/streamstore", async () => {
+	const actual = await vi.importActual<typeof import("@s2-dev/streamstore")>(
+		"@s2-dev/streamstore",
+	);
+	class MockS2 {
+		basin() {
+			return { stream: () => mock.handle };
+		}
+	}
+	return { ...actual, S2: MockS2 };
+});
+
+/** A ReadBatch whose single record is a terminal fence ("stream done"). */
+const doneBatch = {
+	records: [
+		{
+			headers: [["", "fence"]],
+			body: "end-abc12",
+		},
+	],
+};
+
+function makeCtx(waitUntilPromises: Promise<unknown>[] = []) {
+	return import("../../index.js").then(({ createResumableStreamContext }) =>
+		createResumableStreamContext({
+			waitUntil: (p) => {
+				waitUntilPromises.push(p.catch(() => {}));
+			},
+		}),
+	);
+}
+
+describe("Issue #237: no stream is created when validation fails", () => {
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeAll(() => {
+		for (const key of [
+			"S2_ACCESS_TOKEN",
+			"S2_BASIN",
+			"S2_ACCOUNT_ENDPOINT",
+			"S2_BASIN_ENDPOINT",
+		]) {
+			savedEnv[key] = process.env[key];
+		}
+
+		process.env.S2_ACCESS_TOKEN = "ignored";
+		process.env.S2_BASIN = "test-basin";
+		process.env.S2_ACCOUNT_ENDPOINT = "http://localhost:80";
+		process.env.S2_BASIN_ENDPOINT = "http://localhost:80";
+	});
+
+	afterAll(() => {
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("does not invoke makeStream when the stream is already done", async () => {
+		mock.handle = {
+			read: () => Promise.resolve(doneBatch),
+		};
+		const makeStream = vi.fn(() => new ReadableStream<string>());
+		const ctx = await makeCtx();
+
+		const result = await ctx.resumableStream("done-stream", makeStream);
+
+		expect(result).toBeNull();
+		expect(makeStream).not.toHaveBeenCalled();
+	}, 10_000);
+
+	it("does not invoke makeStream when the status check fails", async () => {
+		mock.handle = {
+			read: () => Promise.reject(new Error("boom")),
+		};
+		const makeStream = vi.fn(() => new ReadableStream<string>());
+		const ctx = await makeCtx();
+
+		const result = await ctx.resumableStream("broken-stream", makeStream);
+
+		expect(result).toBeNull();
+		expect(makeStream).not.toHaveBeenCalled();
+	}, 10_000);
+
+	it("does not invoke makeStream when another writer holds the fence", async () => {
+		mock.handle = {
+			read: () => Promise.reject(new RangeNotSatisfiableError()),
+			append: () =>
+				Promise.reject(
+					new FencingTokenMismatchError({
+						message: "fencing token mismatch",
+						expectedFencingToken: "other-writer",
+					}),
+				),
+			// resumeStream path; reject so it resolves to null.
+			readSession: () => Promise.reject(new Error("Not Found (404)")),
+		};
+		const makeStream = vi.fn(() => new ReadableStream<string>());
+		const ctx = await makeCtx();
+
+		const result = await ctx.resumableStream("contested-stream", makeStream);
+
+		expect(result).toBeNull();
+		expect(makeStream).not.toHaveBeenCalled();
+	}, 10_000);
+
+	it("does not invoke makeStream when the fence append fails", async () => {
+		mock.handle = {
+			read: () => Promise.reject(new RangeNotSatisfiableError()),
+			append: () => Promise.reject(new Error("append failed")),
+		};
+		const makeStream = vi.fn(() => new ReadableStream<string>());
+		const ctx = await makeCtx();
+
+		const result = await ctx.resumableStream("unappendable-stream", makeStream);
+
+		expect(result).toBeNull();
+		expect(makeStream).not.toHaveBeenCalled();
+	}, 10_000);
+
+	it("creates the stream once and passes values through on success", async () => {
+		mock.handle = {
+			read: () => Promise.reject(new RangeNotSatisfiableError()),
+			append: () =>
+				Promise.resolve({
+					start: { seqNum: 0, timestamp: new Date(0) },
+					end: { seqNum: 1, timestamp: new Date(0) },
+					tail: { seqNum: 1, timestamp: new Date(0) },
+				}),
+			// Fail persistence; the background persist swallows the error.
+			appendSession: () => Promise.reject(new Error("no session in test")),
+			close: () => Promise.resolve(),
+		};
+		const makeStream = vi.fn(
+			() =>
+				new ReadableStream<string>({
+					start(controller) {
+						controller.enqueue("x");
+						controller.enqueue("y");
+						controller.close();
+					},
+				}),
+		);
+		const waitUntilPromises: Promise<unknown>[] = [];
+		const ctx = await makeCtx(waitUntilPromises);
+
+		const result = await ctx.resumableStream("fresh-stream", makeStream);
+
+		expect(makeStream).toHaveBeenCalledTimes(1);
+		expect(result).not.toBeNull();
+
+		const got: string[] = [];
+		const reader = result!.getReader();
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			got.push(value);
+		}
+		expect(got).toEqual(["x", "y"]);
+
+		await Promise.all(waitUntilPromises);
+	}, 10_000);
+});

--- a/packages/streamstore/src/producer.ts
+++ b/packages/streamstore/src/producer.ts
@@ -351,18 +351,15 @@ export class Producer implements AsyncDisposable {
 			this.inflightRecords.length,
 		);
 
-		// Check if pump has already failed
+		// Pump already failed: rethrow the original error (as close() does)
+		// so its type is preserved.
 		if (this.pumpError) {
 			debugProducer(
 				"[%s] submit #%d: pump already failed",
 				this.debugName,
 				submitId,
 			);
-			throw new S2Error({
-				message: `Cannot submit: producer has failed: ${this.pumpError.message}`,
-				status: 500,
-				origin: "sdk",
-			});
+			throw this.pumpError;
 		}
 
 		// Create the ack promise (resolved later by pump)

--- a/packages/streamstore/src/tests/reproductions/issue-236.test.ts
+++ b/packages/streamstore/src/tests/reproductions/issue-236.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { BatchTransform } from "../../batch-transform.js";
+import { FencingTokenMismatchError } from "../../error.js";
+import { AppendRecord } from "../../index.js";
+import {
+	type AcksStream,
+	type AppendSession,
+	BatchSubmitTicket,
+} from "../../lib/stream/types.js";
+import { Producer } from "../../producer.js";
+import { type AppendAck, type AppendInput } from "../../types.js";
+
+/**
+ * Issue #236: after a pump failure, submit() wrapped the error in a generic
+ * S2Error while close() rethrew the original, so takeover errors lost their
+ * FencingTokenMismatchError type. The fix rethrows the original from both.
+ */
+
+/** An append session that rejects every submit with a fencing mismatch. */
+class FencedAppendSession implements AppendSession {
+	readonly readable = new ReadableStream<AppendAck>();
+	readonly writable = new WritableStream<AppendInput>();
+	private readonly acksStream: AcksStream =
+		new ReadableStream<AppendAck>() as AcksStream;
+
+	constructor(private readonly error: FencingTokenMismatchError) {}
+
+	async submit(_input: AppendInput): Promise<BatchSubmitTicket> {
+		throw this.error;
+	}
+
+	async close(): Promise<void> {}
+
+	acks(): AcksStream {
+		return this.acksStream;
+	}
+
+	lastAckedPosition(): AppendAck | undefined {
+		return undefined;
+	}
+
+	failureCause(): undefined {
+		return undefined;
+	}
+
+	async [Symbol.asyncDispose](): Promise<void> {
+		await this.close();
+	}
+}
+
+function makeProducer(error: FencingTokenMismatchError): Producer {
+	return new Producer(
+		new BatchTransform({ lingerDurationMillis: 0, maxBatchRecords: 1 }),
+		new FencedAppendSession(error),
+	);
+}
+
+describe("Issue #236: submit() preserves the pump error type", () => {
+	it("rethrows the original FencingTokenMismatchError from later submits", async () => {
+		const fencing = new FencingTokenMismatchError({
+			message: "fencing token mismatch",
+			expectedFencingToken: "other-writer",
+		});
+		const producer = makeProducer(fencing);
+
+		// First submit is accepted; its ack rejects with the pump error.
+		const ticket = await producer.submit(AppendRecord.string({ body: "a" }));
+		await expect(ticket.ack()).rejects.toBe(fencing);
+
+		// Later submits must surface the same error, not a generic wrapper.
+		await expect(
+			producer.submit(AppendRecord.string({ body: "b" })),
+		).rejects.toBe(fencing);
+
+		// close() already rethrew the original; both paths now agree.
+		await expect(producer.close()).rejects.toBe(fencing);
+	});
+
+	it("keeps the error recognizable via instanceof across submit and close", async () => {
+		const fencing = new FencingTokenMismatchError({
+			message: "fencing token mismatch",
+			expectedFencingToken: "other-writer",
+		});
+		const producer = makeProducer(fencing);
+
+		const ticket = await producer.submit(AppendRecord.string({ body: "a" }));
+		await ticket.ack().catch(() => {});
+
+		const errors: unknown[] = [];
+		try {
+			await producer.submit(AppendRecord.string({ body: "fence" }));
+		} catch (err) {
+			errors.push(err);
+		}
+		try {
+			await producer.close();
+		} catch (err) {
+			errors.push(err);
+		}
+
+		expect(errors).toHaveLength(2);
+		// The adapter's takeover predicate must hold for every member.
+		expect(
+			errors.every((err) => err instanceof FencingTokenMismatchError),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #237, fixes #236, fixes #234.

Three independent, verified fixes — one commit per issue, each with a `tests/reproductions/issue-NNN.test.ts` regression test.

## #237 — `createResumableStream` leaked the teed streams on validation failure

`makeStream().tee()` ran before validation; all four early-return paths (stream done, status-check error, fence held by another writer, fence-append failure) abandoned both branches without `cancel()`, and the caller never receives a handle it could cancel itself.

**Fix:** defer `makeStream()` until validation succeeds. Nothing is created on the early returns — no leak class to maintain, and the factory's upstream work (e.g. LLM generation) is never started for a stream that resolves to `null` or resumes. Trade-off: on the happy path the factory now starts after validation (~2 RTTs later) instead of eagerly.

## #236 — expected takeovers logged as errors during finalization

After a pump failure, `Producer.submit()` threw a fresh generic `S2Error` built from `pumpError.message`, while `close()` rethrew the original. A takeover mid-persist therefore surfaced as `AggregateError([S2Error, FencingTokenMismatchError])`, failing the adapter's `errors.every(e => e instanceof FencingTokenMismatchError)` check and producing spurious error logs for an expected operational event.

**Fix:** `submit()` rethrows the original pump error, matching `close()`. Since the same instance now surfaces from every phase of `persistToS2`, `combineErrors` dedupes by identity so the failure arrives as a single recognizable error instead of `AggregateError([x, x, x])`. Kept `.every()` in the adapter deliberately: with homogeneous aggregates guaranteed for pure takeovers, `.some()` would mask genuine unrelated errors that co-occur with one.

## #234 — `pipeSseFrames` kept the connection open on early termination

The `finally` block only called `releaseLock()`, which does not cancel the underlying stream. A consumer that stopped iterating (`break`/`return`/throw) without an abort signal left the fetch body open — the server kept streaming to a dead client.

**Fix:** cancel the reader on the way out so cancellation propagates through the `pipeThrough` chain to the fetch body. Cancel errors are swallowed unconditionally (an already-errored stream's `cancel()` rejects; rethrowing from `finally` would mask the original error).

## Verification

- **Red/green:** with the source fixes stashed, exactly the 9 bug-targeting tests fail (the #236 failure reproduces the literal `"Cannot submit: producer has failed"` wrapper); the 3 behavior-preservation guards (abort-signal path, finite-stream completion, happy-path creation) pass both before and after.
- **Full suite:** 79 files / 487 unit tests pass; `bun run check` (biome + `tsc --noEmit` across packages) clean.
- New cross-package test asserts `persistToS2`'s failure during a takeover stays classifiable with the adapter's exact predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)