### PR TITLE
fix: clarify error for unnegotiated compressed S2S frames

### DIFF
--- a/.changeset/s2s-unexpected-compressed-frame.md
+++ b/.changeset/s2s-unexpected-compressed-frame.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Report a clear protocol error when the S2S transport receives a compressed frame for an algorithm that was never negotiated, instead of the misleading "zlib module has not been loaded".

--- a/packages/streamstore/src/lib/stream/transport/s2s/compression.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/compression.ts
@@ -38,8 +38,6 @@ async function loadZlib(): Promise<CompressionModule> {
 
 function getLoadedZlib(type: CompressionType): CompressionModule {
 	if (!zlibModule) {
-		// zlib is only loaded when compression is negotiated. Reaching here means
-		// the server sent a compressed frame the client never advertised support for.
 		throw new Error(
 			`received unexpected ${type}-compressed frame: compression was not negotiated`,
 		);

--- a/packages/streamstore/src/lib/stream/transport/s2s/compression.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/compression.ts
@@ -36,9 +36,13 @@ async function loadZlib(): Promise<CompressionModule> {
 	return zlibPromise;
 }
 
-function getLoadedZlib(): CompressionModule {
+function getLoadedZlib(type: CompressionType): CompressionModule {
 	if (!zlibModule) {
-		throw new Error("zlib module has not been loaded");
+		// zlib is only loaded when compression is negotiated. Reaching here means
+		// the server sent a compressed frame the client never advertised support for.
+		throw new Error(
+			`received unexpected ${type}-compressed frame: compression was not negotiated`,
+		);
 	}
 	return zlibModule;
 }
@@ -117,11 +121,11 @@ export function decompressFrameBody(
 			return body;
 		}
 		case "gzip":
-			return getLoadedZlib().gunzipSync(body, {
+			return getLoadedZlib(type).gunzipSync(body, {
 				maxOutputLength: MAX_DECOMPRESSED_PAYLOAD_BYTES,
 			});
 		case "zstd": {
-			const z = getLoadedZlib();
+			const z = getLoadedZlib(type);
 			if (!z.zstdDecompressSync) {
 				throw new Error("zstd decompression requires Node.js v22.15+");
 			}

--- a/packages/streamstore/src/tests/s2s-compression.test.ts
+++ b/packages/streamstore/src/tests/s2s-compression.test.ts
@@ -1,5 +1,5 @@
 import * as zlib from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	acceptEncodingHeader,
 	compressFrameBody,
@@ -134,6 +134,18 @@ describe("s2s frame compression round-trip", () => {
 		parser.push(rawFrame(1, 0x80));
 		expect(() => parser.parseFrame()).toThrow(
 			"terminal message missing status code",
+		);
+	});
+
+	it("reports a protocol error for unnegotiated compressed frames", async () => {
+		// Re-import a fresh module so zlib is unloaded, mimicking a client running
+		// with compression "none" that receives a compressed frame anyway. This
+		// must surface as a negotiation error, not a generic module-load failure.
+		vi.resetModules();
+		const fresh = await import("../lib/stream/transport/s2s/compression.js");
+		const compressed = zlib.gzipSync(new Uint8Array([1, 2, 3]));
+		expect(() => fresh.decompressFrameBody(compressed, "gzip")).toThrow(
+			/unexpected gzip-compressed frame/,
 		);
 	});
 

--- a/packages/streamstore/src/tests/s2s-compression.test.ts
+++ b/packages/streamstore/src/tests/s2s-compression.test.ts
@@ -138,9 +138,7 @@ describe("s2s frame compression round-trip", () => {
 	});
 
 	it("reports a protocol error for unnegotiated compressed frames", async () => {
-		// Re-import a fresh module so zlib is unloaded, mimicking a client running
-		// with compression "none" that receives a compressed frame anyway. This
-		// must surface as a negotiation error, not a generic module-load failure.
+		// Fresh module so zlib is unloaded, as it would be with compression "none".
 		vi.resetModules();
 		const fresh = await import("../lib/stream/transport/s2s/compression.js");
 		const compressed = zlib.gzipSync(new Uint8Array([1, 2, 3]));


### PR DESCRIPTION
Fixes #282

## Problem

The S2S transport lazy-loads zlib only when compression is negotiated. The decode path takes its compression type from the **server's frame** (`frame.compression`), not the client config. So when a client sets `compression: "none"` (zlib never loaded) but the server sends a compressed frame anyway, `decompressFrameBody` hit `getLoadedZlib()` and threw a generic `"zlib module has not been loaded"`.

That message misdirects debugging toward client configuration when the real problem is a server-side protocol violation (sending an algorithm the client never advertised).

## Fix

- `getLoadedZlib(type)` now throws a contextual error naming the offending algorithm: `received unexpected <type>-compressed frame: compression was not negotiated`.
- Added a regression test that re-imports a fresh module (so zlib is genuinely unloaded, since the module-level cache is warmed by earlier tests) and asserts the new error.
- Added a changeset (patch bump).

## Verification

- `npx vitest run src/tests/s2s-compression.test.ts` — 12/12 pass
- `tsc --noEmit` clean
- `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)