### PR TITLE
fix: streams.create() returns normalized StreamInfo

### DIFF
--- a/.changeset/create-stream-returns-streaminfo.md
+++ b/.changeset/create-stream-returns-streaminfo.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Fix `streams.create()` to return `StreamInfo` (with `name`, `createdAt`, `deletedAt`) and normalize date fields to `Date` objects, matching `list()` and `ensure()`. It was previously typed as `{ config }` and left dates as raw strings.

--- a/packages/streamstore/src/streams.ts
+++ b/packages/streamstore/src/streams.ts
@@ -190,7 +190,7 @@ export class S2Streams {
 				}),
 			);
 		});
-		return toCamelCase<Types.CreateStreamResponse>(response);
+		return transformStreamInfo(toCamelCase<any>(response));
 	}
 
 	/**

--- a/packages/streamstore/src/tests/reproductions/issue-280.test.ts
+++ b/packages/streamstore/src/tests/reproductions/issue-280.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../generated/index.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../generated/index.js")
+	>("../../generated/index.js");
+	return {
+		...actual,
+		createStream: vi.fn(),
+	};
+});
+
+import * as Generated from "../../generated/index.js";
+import { S2Streams } from "../../streams.js";
+
+/**
+ * Issue #280: create() returns StreamInfo (name, createdAt, deletedAt), but was
+ * typed as { config } and skipped transformStreamInfo, so callers saw an
+ * undefined `config` and dates left as raw strings.
+ */
+describe("Issue #280: create() returns normalized StreamInfo", () => {
+	it("exposes StreamInfo fields with dates as Date objects", async () => {
+		vi.mocked(Generated.createStream).mockResolvedValue({
+			data: {
+				created_at: "2024-01-01T00:00:00Z",
+				deleted_at: null,
+				name: "events",
+			},
+			response: { headers: new Headers(), status: 201 },
+		} as any);
+
+		const streams = new S2Streams({} as any, {} as any);
+		const info = await streams.create({ stream: "events" });
+
+		expect(info.name).toBe("events");
+		expect(info.createdAt).toBeInstanceOf(Date);
+		expect(info.deletedAt).toBeNull();
+		expect((info as unknown as { config?: unknown }).config).toBeUndefined();
+	});
+});

--- a/packages/streamstore/src/tests/streams.spec.e2e.test.ts
+++ b/packages/streamstore/src/tests/streams.spec.e2e.test.ts
@@ -171,6 +171,21 @@ describeIf("Streams spec parity", () => {
 		);
 
 		it(
+			"returns StreamInfo with normalized dates",
+			async () => {
+				const streamName = makeStreamName("ts-info");
+				try {
+					const info = await basin.streams.create({ stream: streamName });
+					expect(info.name).toBe(streamName);
+					expect(info.createdAt).toBeInstanceOf(Date);
+				} finally {
+					await basin.streams.delete({ stream: streamName }).catch(() => {});
+				}
+			},
+			TEST_TIMEOUT_MS,
+		);
+
+		it(
 			"creates with full config",
 			async () => {
 				const streamName = await createStream("ts-full", {

--- a/packages/streamstore/src/types.ts
+++ b/packages/streamstore/src/types.ts
@@ -541,10 +541,7 @@ export interface ListStreamsResponse {
 /**
  * Response from creating a stream.
  */
-export interface CreateStreamResponse {
-	/** Stream configuration. */
-	config: StreamConfig;
-}
+export type CreateStreamResponse = StreamInfo;
 
 /**
  * Response from ensuring a stream.


### PR DESCRIPTION
Fixes #280

## Problem

`streams.create()` was typed as `{ config: StreamConfig }` and returned `toCamelCase(response)` without `transformStreamInfo()`. But the API actually returns `StreamInfo` (201) — so callers got an `undefined` `config`, and `createdAt`/`deletedAt` were left as raw strings instead of `Date` objects, unlike `list()` and `ensure()`.

## Verification across SDKs and spec

I checked the OpenAPI spec and the sibling implementations — all agree the create-stream response is `StreamInfo`:

| Source | create-stream returns | dates |
| --- | --- | --- |
| `s2-specs` OpenAPI (`create_stream` 201) | `StreamInfo` | RFC 3339 strings |
| Rust OSS server (`s2-oss/s2`) | `StreamInfo` (HTTP 201) | `OffsetDateTime` |
| Go SDK (`s2-sdk-go`) | `*StreamInfo` | `time.Time` |
| Python SDK (`s2-sdk-python`) | `StreamInfo` | `datetime` |
| TS SDK `basins.create` | `BasinInfo` (already normalized) | `Date` |

So the old TS behavior was the odd one out — this is a genuine bug, not just a cosmetic type tweak.

## Fix

- `CreateStreamResponse` is now `StreamInfo` (matches the generated API type).
- `create()` runs the response through `transformStreamInfo()`, normalizing dates to `Date`.

## Tests

- New unit reproduction `reproductions/issue-280.test.ts` — verified it fails on the old code (dates stay strings) and passes with the fix.
- Added an e2e assertion that `create()` returns a `StreamInfo` with a `Date` `createdAt`.
- Full unit suite: 410 passing; `tsc --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)