### PR TITLE
fix: cancel teed branch on early stop to avoid client cancel hang

### DIFF
--- a/.changeset/resumable-stream-cancel-hang.md
+++ b/.changeset/resumable-stream-cancel-hang.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/resumable-stream": patch
+---
+
+Fix client `cancel()` hanging when the persistence branch of the teed stream stops iterating early. `readableStreamToAsyncIterable` now fire-and-forget cancels its reader before releasing the lock, so the abandoned teed branch is released and the sibling branch's `cancel()` resolves.

--- a/packages/resumable-stream/src/index.ts
+++ b/packages/resumable-stream/src/index.ts
@@ -332,7 +332,7 @@ function isStreamDone(readBatch: ReadBatch): boolean {
 	return isTerminalFence(lastRecord);
 }
 
-/** @internal Exported for testing. */
+/** @internal */
 export async function* readableStreamToAsyncIterable(
 	stream: ReadableStream<string>,
 ): AsyncIterable<string> {
@@ -344,8 +344,7 @@ export async function* readableStreamToAsyncIterable(
 			yield value;
 		}
 	} finally {
-		// Cancel (fire-and-forget) so this teed branch is released rather than
-		// abandoned; otherwise cancel() on the sibling branch never resolves.
+		// Cancel so the other tee branch's cancel() can resolve.
 		reader.cancel().catch(() => {});
 		reader.releaseLock();
 	}

--- a/packages/resumable-stream/src/index.ts
+++ b/packages/resumable-stream/src/index.ts
@@ -332,7 +332,8 @@ function isStreamDone(readBatch: ReadBatch): boolean {
 	return isTerminalFence(lastRecord);
 }
 
-async function* readableStreamToAsyncIterable(
+/** @internal Exported for testing. */
+export async function* readableStreamToAsyncIterable(
 	stream: ReadableStream<string>,
 ): AsyncIterable<string> {
 	const reader = stream.getReader();
@@ -343,6 +344,9 @@ async function* readableStreamToAsyncIterable(
 			yield value;
 		}
 	} finally {
+		// Cancel (fire-and-forget) so this teed branch is released rather than
+		// abandoned; otherwise cancel() on the sibling branch never resolves.
+		reader.cancel().catch(() => {});
 		reader.releaseLock();
 	}
 }

--- a/packages/resumable-stream/src/tests/reproductions/issue-275.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-275.test.ts
@@ -1,20 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { readableStreamToAsyncIterable } from "../../index.js";
 
-/**
- * Issue #275: persistence consumes one teed branch via
- * readableStreamToAsyncIterable. When that iteration stops early it released
- * the reader lock without cancelling, leaving the branch abandoned — so a
- * later cancel() on the sibling (client) branch never resolved. The fix
- * fire-and-forget cancels the branch in the generator's finally block.
- */
+// Issue #275: stopping one tee branch early must not hang cancel() on the other.
 
 function ongoingSource(): ReadableStream<string> {
 	return new ReadableStream<string>({
 		start(controller) {
 			controller.enqueue("a");
 			controller.enqueue("b");
-			// Never closes: simulates a producer still emitting tokens.
 		},
 	});
 }
@@ -31,17 +24,15 @@ async function withTimeout<T>(
 	]);
 }
 
-describe("Issue #275: cancelling the client branch after persistence stops early", () => {
-	it("does not hang the sibling branch's cancel()", async () => {
+describe("Issue #275: cancelling one tee branch after the other stops early", () => {
+	it("does not hang cancel() on the other branch", async () => {
 		const [persistent, client] = ongoingSource().tee();
 
-		// Persistence reads one value, then stops early (loop body breaks/throws).
-		const iterable = readableStreamToAsyncIterable(persistent);
-		const iterator = iterable[Symbol.asyncIterator]();
+		const iterator =
+			readableStreamToAsyncIterable(persistent)[Symbol.asyncIterator]();
 		await iterator.next();
-		await iterator.return?.(undefined); // runs the generator's finally
+		await iterator.return?.(undefined);
 
-		// The client now cancels its branch; this must resolve promptly.
 		const result = await withTimeout(client.cancel(), 500);
 		expect(result).not.toBe("TIMEOUT");
 	});

--- a/packages/resumable-stream/src/tests/reproductions/issue-275.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-275.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { readableStreamToAsyncIterable } from "../../index.js";
+
+/**
+ * Issue #275: persistence consumes one teed branch via
+ * readableStreamToAsyncIterable. When that iteration stops early it released
+ * the reader lock without cancelling, leaving the branch abandoned — so a
+ * later cancel() on the sibling (client) branch never resolved. The fix
+ * fire-and-forget cancels the branch in the generator's finally block.
+ */
+
+function ongoingSource(): ReadableStream<string> {
+	return new ReadableStream<string>({
+		start(controller) {
+			controller.enqueue("a");
+			controller.enqueue("b");
+			// Never closes: simulates a producer still emitting tokens.
+		},
+	});
+}
+
+async function withTimeout<T>(
+	p: Promise<T>,
+	ms: number,
+): Promise<T | "TIMEOUT"> {
+	return Promise.race([
+		p,
+		new Promise<"TIMEOUT">((resolve) =>
+			setTimeout(() => resolve("TIMEOUT"), ms),
+		),
+	]);
+}
+
+describe("Issue #275: cancelling the client branch after persistence stops early", () => {
+	it("does not hang the sibling branch's cancel()", async () => {
+		const [persistent, client] = ongoingSource().tee();
+
+		// Persistence reads one value, then stops early (loop body breaks/throws).
+		const iterable = readableStreamToAsyncIterable(persistent);
+		const iterator = iterable[Symbol.asyncIterator]();
+		await iterator.next();
+		await iterator.return?.(undefined); // runs the generator's finally
+
+		// The client now cancels its branch; this must resolve promptly.
+		const result = await withTimeout(client.cancel(), 500);
+		expect(result).not.toBe("TIMEOUT");
+	});
+});

--- a/packages/resumable-stream/tsconfig.json
+++ b/packages/resumable-stream/tsconfig.json
@@ -4,6 +4,7 @@
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"declaration": true,
+		"stripInternal": true,
 		"outDir": "dist",
 		"rootDir": "src",
 		"strict": true,


### PR DESCRIPTION
Fixes #275

## Problem

`createResumableStream` tees the source into a `persistentStream` (consumed by `persistToS2` through `readableStreamToAsyncIterable`) and a `clientStream` (returned to the caller). When persistence stops iterating early — an error or break in the consumer — the generator's `finally` ran `reader.releaseLock()` **without** `reader.cancel()`, leaving that teed branch *abandoned* rather than cancelled.

Per the `tee()` spec, the underlying source's composite cancel only completes once **both** branches cancel. With one branch merely abandoned, a later `clientStream.cancel()` never resolves — it hangs forever, and the upstream producer (e.g. an LLM) keeps consuming resources.

## Fix

```ts
} finally {
  reader.cancel().catch(() => {});
  reader.releaseLock();
}
```

Fire-and-forget is essential: awaiting the persistent branch's own cancel would itself hang, since its completion also waits on the client branch. Setting the cancelled flag without blocking lets the client branch's later cancel complete the composite cancel.

## Verification

- Added `reproductions/issue-275.test.ts`, which tees a never-closing source, stops the persistence branch early, then cancels the client branch under a timeout. **Verified it fails (times out / hangs) without the fix and passes with it.**
- Exported `readableStreamToAsyncIterable` with an `@internal` tag so the test exercises the real function rather than a copy.
- Full unit suite: 66 passing; `tsc --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)