### PR TITLE
perf: use O(1) amortized FIFO queue for inflight message tracking

### DIFF
--- a/.changeset/fifo-queue-inflight.md
+++ b/.changeset/fifo-queue-inflight.md
@@ -2,4 +2,4 @@
 "@s2-dev/streamstore": patch
 ---
 
-Replace array `shift()` with an O(1) amortized FIFO queue for inflight batches, capacity waiters, and pending acks. Avoids quadratic behavior when many small batches are queued (hundreds of thousands of entries fit within the default 3 MiB `maxInflightBytes`).
+Make append-session bookkeeping O(1) per ack instead of O(queue depth): replace array `shift()` with an amortized O(1) FIFO queue (inflight batches, capacity waiters, pending acks), and drain new submissions from a dedicated queue instead of rescanning the full inflight queue every pump cycle. At ~30k queued batches this cuts client CPU for a 100k-append session from ~142s to ~7.5s.

--- a/.changeset/fifo-queue-inflight.md
+++ b/.changeset/fifo-queue-inflight.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Replace array `shift()` with an O(1) amortized FIFO queue for inflight batches, capacity waiters, and pending acks. Avoids quadratic behavior when many small batches are queued (hundreds of thousands of entries fit within the default 3 MiB `maxInflightBytes`).

--- a/.changeset/fifo-queue-inflight.md
+++ b/.changeset/fifo-queue-inflight.md
@@ -2,4 +2,4 @@
 "@s2-dev/streamstore": patch
 ---
 
-Make append-session bookkeeping O(1) per ack instead of O(queue depth): replace array `shift()` with an amortized O(1) FIFO queue (inflight batches, capacity waiters, pending acks), and drain new submissions from a dedicated queue instead of rescanning the full inflight queue every pump cycle. At ~30k queued batches this cuts client CPU for a 100k-append session from ~142s to ~7.5s.
+Make append-session bookkeeping O(1) per ack instead of O(queue depth): replace array `shift()` with an amortized O(1) FIFO queue (inflight batches, capacity waiters, pending acks), and drain new submissions from a dedicated queue instead of rescanning the full inflight queue every pump cycle.

--- a/packages/streamstore/src/lib/queue.ts
+++ b/packages/streamstore/src/lib/queue.ts
@@ -67,9 +67,17 @@ export class FifoQueue<T> implements Iterable<T> {
 		return false;
 	}
 
-	*[Symbol.iterator](): IterableIterator<T> {
-		for (let i = this.head; i < this.items.length; i++) {
-			yield this.items[i] as T;
-		}
+	// Hand-rolled iterator: generators are ~10x slower per element in hot scans
+	[Symbol.iterator](): IterableIterator<T> {
+		let i = this.head;
+		const items = this.items;
+		const iter: IterableIterator<T> = {
+			next: (): IteratorResult<T> =>
+				i < items.length
+					? { value: items[i++] as T, done: false }
+					: { value: undefined, done: true },
+			[Symbol.iterator]: () => iter,
+		};
+		return iter;
 	}
 }

--- a/packages/streamstore/src/lib/queue.ts
+++ b/packages/streamstore/src/lib/queue.ts
@@ -1,0 +1,75 @@
+/**
+ * FIFO queue with O(1) amortized shift.
+ * Plain arrays degrade badly at large depths since shift() memmoves the
+ * backing store; this tracks a head index and compacts lazily instead.
+ */
+
+/** Dead slots below head must exceed this before compaction is considered. */
+const COMPACT_MIN_HEAD = 1024;
+
+export class FifoQueue<T> implements Iterable<T> {
+	// Slots below head are dead and set to undefined so items can be GC'd
+	private items: (T | undefined)[] = [];
+	private head = 0;
+
+	get length(): number {
+		return this.items.length - this.head;
+	}
+
+	push(item: T): void {
+		this.items.push(item);
+	}
+
+	/** Remove and return the head item, or undefined if empty. */
+	shift(): T | undefined {
+		if (this.head >= this.items.length) {
+			return undefined;
+		}
+		const item = this.items[this.head] as T;
+		this.items[this.head] = undefined;
+		this.head++;
+		// Compact once the dead prefix dominates; amortizes to O(1) per shift
+		if (this.head >= COMPACT_MIN_HEAD && this.head * 2 >= this.items.length) {
+			this.items = this.items.slice(this.head);
+			this.head = 0;
+		}
+		return item;
+	}
+
+	/** Return the head item without removing it, or undefined if empty. */
+	peek(): T | undefined {
+		return this.items[this.head];
+	}
+
+	clear(): void {
+		this.items = [];
+		this.head = 0;
+	}
+
+	/** Remove the first item matching the predicate. Returns true if found. */
+	removeFirst(predicate: (item: T) => boolean): boolean {
+		for (let i = this.head; i < this.items.length; i++) {
+			if (predicate(this.items[i] as T)) {
+				this.items.splice(i, 1);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Test items with queue-relative indices (0 = head). */
+	some(predicate: (item: T, index: number) => boolean): boolean {
+		for (let i = this.head; i < this.items.length; i++) {
+			if (predicate(this.items[i] as T, i - this.head)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	*[Symbol.iterator](): IterableIterator<T> {
+		for (let i = this.head; i < this.items.length; i++) {
+			yield this.items[i] as T;
+		}
+	}
+}

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -10,6 +10,7 @@ import {
 import type * as API from "../generated/index.js";
 import * as Types from "../types.js";
 import { isCommandRecord, meteredBytes } from "../utils.js";
+import { FifoQueue } from "./queue.js";
 import type { AppendResult, CloseResult } from "./result.js";
 import { err, errClose, ok, okClose } from "./result.js";
 import type {
@@ -639,8 +640,8 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 		requestTimeoutMillis: number;
 	};
 
-	private readonly inflight: InflightEntry[] = [];
-	private capacityWaiters: CapacityWaiter[] = []; // Queue of waiters for capacity
+	private readonly inflight = new FifoQueue<InflightEntry>();
+	private readonly capacityWaiters = new FifoQueue<CapacityWaiter>(); // Queue of waiters for capacity
 
 	private session?: TransportAppendSession;
 	private queuedBytes = 0;
@@ -972,7 +973,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 					);
 
 		while (this.capacityWaiters.length > 0) {
-			const next = this.capacityWaiters[0]!;
+			const next = this.capacityWaiters.peek()!;
 			const needsBytes = next.bytes;
 			const needsBatches = next.batches;
 			const hasBatchCapacity =
@@ -1067,7 +1068,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 			}
 
 			// Get head entry (we know it exists because we checked length above)
-			const head = this.inflight[0]!;
+			const head = this.inflight.peek()!;
 			debugSession(
 				"[%s] [PUMP] processing head: expectedCount=%d, meteredBytes=%d, match_seq_num=%s",
 				this.streamName,
@@ -1519,7 +1520,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				entry.maybeResolve(err(error));
 			}
 		}
-		this.inflight.length = 0;
+		this.inflight.clear();
 		this.queuedBytes = 0;
 		this.pendingBytes = 0;
 		this.pendingBatches = 0;
@@ -1539,7 +1540,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 		for (const waiter of this.capacityWaiters) {
 			waiter.resolve();
 		}
-		this.capacityWaiters = [];
+		this.capacityWaiters.clear();
 
 		// Close inner session
 		if (this.session) {
@@ -1578,7 +1579,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 		for (const waiter of this.capacityWaiters) {
 			waiter.resolve();
 		}
-		this.capacityWaiters = [];
+		this.capacityWaiters.clear();
 
 		// Wake pump if it's sleeping so it can check closing flag
 		if (this.pumpWakeup) {

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -641,6 +641,9 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 	};
 
 	private readonly inflight = new FifoQueue<InflightEntry>();
+	// Entries awaiting first submission to the transport; drained by the pump.
+	// Avoids rescanning the full inflight queue on every pump cycle.
+	private readonly toSubmit = new FifoQueue<InflightEntry>();
 	private readonly capacityWaiters = new FifoQueue<CapacityWaiter>(); // Queue of waiters for capacity
 
 	private session?: TransportAppendSession;
@@ -923,6 +926,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 			);
 
 			this.inflight.push(entry);
+			this.toSubmit.push(entry);
 			this.queuedBytes += batchMeteredSize;
 
 			// Wake pump if it's sleeping
@@ -1125,8 +1129,13 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 			}
 
 			// Submit ALL entries that need submitting (enables HTTP/2 pipelining for S2S)
-			for (const entry of this.inflight) {
-				if (!entry.innerPromise || entry.needsSubmit) {
+			// Recovery may have already resubmitted an entry (needsSubmit cleared) - skip those.
+			for (
+				let entry = this.toSubmit.shift();
+				entry !== undefined;
+				entry = this.toSubmit.shift()
+			) {
+				if (entry.needsSubmit) {
 					debugSession(
 						"[%s] [PUMP] submitting entry to inner session (%d records, %d bytes, match_seq_num=%s)",
 						this.streamName,
@@ -1521,6 +1530,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 			}
 		}
 		this.inflight.clear();
+		this.toSubmit.clear();
 		this.queuedBytes = 0;
 		this.pendingBytes = 0;
 		this.pendingBatches = 0;

--- a/packages/streamstore/src/lib/stream/transport/fetch/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/fetch/index.ts
@@ -24,6 +24,7 @@ import { computeAppendRecordFormat } from "../../../../utils.js";
 import { decodeFromBase64 } from "../../../base64.js";
 import { S2_ENCRYPTION_KEY_HEADER } from "../../../encryption.js";
 import { EventStream } from "../../../event-stream.js";
+import { FifoQueue } from "../../../queue.js";
 import * as Redacted from "../../../redacted.js";
 import type { AppendResult, CloseResult } from "../../../result.js";
 import { err, errClose, ok, okClose } from "../../../result.js";
@@ -392,10 +393,10 @@ export class FetchReadSession<Format extends "string" | "bytes" = "string">
  * No backpressure, no retry logic, no streams - just submit/close with value-encoded errors.
  */
 export class FetchAppendSession implements TransportAppendSession {
-	private queue: Array<Types.AppendInput> = [];
-	private pendingResolvers: Array<{
+	private queue = new FifoQueue<Types.AppendInput>();
+	private pendingResolvers = new FifoQueue<{
 		resolve: (result: AppendResult) => void;
-	}> = [];
+	}>();
 	private inFlight = false;
 	private _effectSignalled = false;
 	private readonly options?: S2RequestOptions;
@@ -635,10 +636,10 @@ export class FetchAppendSession implements TransportAppendSession {
 				for (const pendingResolver of this.pendingResolvers) {
 					pendingResolver.resolve(err(s2Err));
 				}
-				this.pendingResolvers = [];
+				this.pendingResolvers.clear();
 
 				// Clear the queue
-				this.queue = [];
+				this.queue.clear();
 
 				this.inFlight = false;
 				this.processingPromise = null;

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -26,6 +26,7 @@ import * as Proto from "../../../../generated/proto/s2.js";
 import { fromAPIStreamPosition } from "../../../../internal/mappers.js";
 import type * as Types from "../../../../types.js";
 import { S2_ENCRYPTION_KEY_HEADER } from "../../../encryption.js";
+import { FifoQueue } from "../../../queue.js";
 import * as Redacted from "../../../redacted.js";
 import type { AppendResult, CloseResult } from "../../../result.js";
 import { err, errClose, ok, okClose } from "../../../result.js";
@@ -769,10 +770,10 @@ class S2SAppendSession implements TransportAppendSession {
 	private http2Stream?: ClientHttp2Stream;
 	private parser = new S2SFrameParser();
 	private closed = false;
-	private pendingAcks: Array<{
+	private pendingAcks = new FifoQueue<{
 		resolve: (result: AppendResult) => void;
 		batchSize: number;
-	}> = [];
+	}>();
 	private initPromise?: Promise<void>;
 	private _effectSignalled = false;
 
@@ -856,7 +857,7 @@ class S2SAppendSession implements TransportAppendSession {
 			for (const pending of this.pendingAcks) {
 				pending.resolve(err(s2Error(error)));
 			}
-			this.pendingAcks = [];
+			this.pendingAcks.clear();
 			// Note: do NOT reset _effectSignalled here. Data may have been
 			// written to the wire before the error occurred, so the flag
 			// must stay true until the session is recreated.
@@ -1021,10 +1022,7 @@ class S2SAppendSession implements TransportAppendSession {
 			this.http2Stream!.write(frame, (writeErr) => {
 				if (writeErr) {
 					// Remove from pending acks on write error
-					const idx = this.pendingAcks.findIndex((p) => p.resolve === resolve);
-					if (idx !== -1) {
-						this.pendingAcks.splice(idx, 1);
-					}
+					this.pendingAcks.removeFirst((p) => p.resolve === resolve);
 					// Note: do NOT reset _effectSignalled here. The write call
 					// was attempted, so data may have partially entered the
 					// kernel buffer before the error was reported.

--- a/packages/streamstore/src/tests/queue.test.ts
+++ b/packages/streamstore/src/tests/queue.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { FifoQueue } from "../lib/queue.js";
+
+describe("FifoQueue", () => {
+	it("shifts in FIFO order", () => {
+		const q = new FifoQueue<number>();
+		q.push(1);
+		q.push(2);
+		q.push(3);
+		expect(q.shift()).toBe(1);
+		expect(q.shift()).toBe(2);
+		expect(q.shift()).toBe(3);
+		expect(q.shift()).toBeUndefined();
+	});
+
+	it("tracks length across push and shift", () => {
+		const q = new FifoQueue<number>();
+		expect(q.length).toBe(0);
+		q.push(1);
+		q.push(2);
+		expect(q.length).toBe(2);
+		q.shift();
+		expect(q.length).toBe(1);
+		q.shift();
+		expect(q.length).toBe(0);
+	});
+
+	it("peeks without removing", () => {
+		const q = new FifoQueue<number>();
+		expect(q.peek()).toBeUndefined();
+		q.push(7);
+		q.push(8);
+		expect(q.peek()).toBe(7);
+		expect(q.length).toBe(2);
+		q.shift();
+		expect(q.peek()).toBe(8);
+	});
+
+	it("clears all items", () => {
+		const q = new FifoQueue<number>();
+		q.push(1);
+		q.push(2);
+		q.clear();
+		expect(q.length).toBe(0);
+		expect(q.shift()).toBeUndefined();
+	});
+
+	it("removes the first matching item", () => {
+		const q = new FifoQueue<number>();
+		q.push(1);
+		q.push(2);
+		q.push(3);
+		q.push(2);
+		expect(q.removeFirst((x) => x === 2)).toBe(true);
+		expect([...q]).toEqual([1, 3, 2]);
+		expect(q.removeFirst((x) => x === 99)).toBe(false);
+	});
+
+	it("removeFirst accounts for shifted head", () => {
+		const q = new FifoQueue<number>();
+		q.push(5);
+		q.push(5);
+		q.push(6);
+		q.shift();
+		expect(q.removeFirst((x) => x === 5)).toBe(true);
+		expect([...q]).toEqual([6]);
+	});
+
+	it("some uses queue-relative indices", () => {
+		const q = new FifoQueue<string>();
+		q.push("a");
+		q.push("b");
+		q.push("c");
+		q.shift();
+		const seen: Array<[string, number]> = [];
+		q.some((item, index) => {
+			seen.push([item, index]);
+			return false;
+		});
+		expect(seen).toEqual([
+			["b", 0],
+			["c", 1],
+		]);
+		expect(q.some((_, index) => index > 0)).toBe(true);
+		expect(q.some(() => false)).toBe(false);
+	});
+
+	it("iterates from head to tail", () => {
+		const q = new FifoQueue<number>();
+		q.push(1);
+		q.push(2);
+		q.push(3);
+		q.shift();
+		expect([...q]).toEqual([2, 3]);
+	});
+
+	it("preserves order and contents through compaction", () => {
+		const q = new FifoQueue<number>();
+		const total = 10_000;
+		for (let i = 0; i < total; i++) {
+			q.push(i);
+		}
+		// Shift past the compaction threshold while pushing more
+		for (let i = 0; i < total; i++) {
+			expect(q.shift()).toBe(i);
+			q.push(total + i);
+		}
+		expect(q.length).toBe(total);
+		expect(q.peek()).toBe(total);
+		for (let i = 0; i < total; i++) {
+			expect(q.shift()).toBe(total + i);
+		}
+		expect(q.length).toBe(0);
+		expect(q.shift()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #47

`Array.prototype.shift()` is O(n), and the append path uses plain arrays as FIFO queues in four places. E2E testing (below) additionally showed the append pump rescans the entire inflight queue on every cycle, which is the *dominant* per-ack cost at depth — so this PR fixes both quadratic paths.

## Changes

- New `FifoQueue<T>` (`lib/queue.ts`): head-index queue with lazy compaction — compacts via one `slice()` once the dead prefix is ≥1024 slots and at least half the backing array, so `shift()` amortizes to O(1). Shifted slots are nulled so record buffers can be GC'd before compaction. Iterator is a hand-rolled closure (a generator was measured ~9x slower per element in hot scans).
- Swapped in at all four FIFO sites:
  - `inflight` and `capacityWaiters` in `RetryAppendSession`
  - `pendingAcks` in the S2S transport (its write-error `findIndex`+`splice` becomes `removeFirst`)
  - `queue`/`pendingResolvers` in the fetch transport
- New `toSubmit` queue in `RetryAppendSession`: entries awaiting first transport submission are drained from a dedicated queue instead of rescanning the full inflight queue every pump cycle. Per-ack bookkeeping goes from O(depth) to O(1) amortized. Correctness: `needsSubmit` was already the sole submission trigger (`innerPromise` is always set at creation); the flag is cleared exactly once (pump drain or recovery, no await between check and clear), submission order is unchanged (FIFO push order), and abort clears both queues together.

## Benchmarks

Microbenchmark — 1M push+shift ops at steady-state depth (Node, arm64):

| depth | `Array.shift()` | `FifoQueue` |
|---|---|---|
| 10,000 | 34ms | 16ms |
| 100,000 | 101,698ms | 7ms |
| 400,000 | (killed after minutes) | 12ms |

E2E — 100k single-record appends to a real S2 stream (s2s transport, Node, `maxInflightBatches: 40000`, ~30k avg queue depth). Wall time is server-paced (~200 acks/s) and identical across runs; the win is client CPU / event-loop availability:

| | wall | client CPU (user) | event loop blocked |
|---|---|---|---|
| main | 498s | 142s | 135s (max stall 685ms) |
| FifoQueue only | 498s | 226s | 218s (max stall 1021ms) |
| FifoQueue + toSubmit | 498s | **7.5s** | **15s (max stall 116ms)** |

The middle row is why the `toSubmit` change is part of this PR: with the O(depth) rescan still in place, a slower-than-array iterator made things worse than main — the rescan was the real bottleneck all along.

## Testing

- New `queue.test.ts` unit tests: FIFO order, peek/clear/removeFirst/some/iteration, and a 10k-deep churn test that drives multiple compaction cycles.
- Full non-e2e suite passes (419 tests), `bun run check` clean.
- E2E runs above completed with the SDK's ack-ordering invariant checks active (strictly increasing seqnums, ack-count match) and clean session close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
