### PR TITLE
fix: throw S2Error on empty serialization instead of TypeError in submit()

### DIFF
--- a/.changeset/serializing-submit-empty.md
+++ b/.changeset/serializing-submit-empty.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore-patterns": patch
+---
+
+Reject empty serializations in `SerializingAppendSession` with a clear `S2Error` instead of crashing. Previously a serializer producing zero bytes (e.g. `JSON.stringify(undefined)`) made `submit()` throw an opaque `TypeError` while `write()` threw an `S2Error`; both paths now throw the same `S2Error` explaining that the serializer must produce at least one byte.

--- a/packages/patterns/src/patterns/serialization.ts
+++ b/packages/patterns/src/patterns/serialization.ts
@@ -25,6 +25,7 @@ import {
 	AppendSession,
 	BatchSubmitTicket,
 	ReadSession,
+	S2Error,
 } from "@s2-dev/streamstore";
 import { nanoid } from "nanoid";
 import { chunkBytes, MAX_CHUNK_BODY_BYTES } from "./chunking.js";
@@ -127,6 +128,13 @@ export class SerializingAppendSession<Message> extends WritableStream<Message> {
 
 	private toRecords(message: Message): AppendRecord[] {
 		const serialized = this.serializer(message);
+		if (serialized.byteLength === 0) {
+			throw new S2Error({
+				message:
+					"Serialized message is empty; the serializer must produce at least one byte",
+				origin: "sdk",
+			});
+		}
 		if (serialized.byteLength > this.maxFrameBytes) {
 			throw new FrameSizeError(
 				`Serialized message is ${serialized.byteLength} bytes, exceeding maxFrameBytes (${this.maxFrameBytes}); readers would reject it. Raise maxFrameBytes on both sessions to allow larger messages`,

--- a/packages/patterns/src/tests/reproductions/issue-279.test.ts
+++ b/packages/patterns/src/tests/reproductions/issue-279.test.ts
@@ -1,0 +1,62 @@
+import { S2Error } from "@s2-dev/streamstore";
+import { describe, expect, it } from "vitest";
+import { SerializingAppendSession } from "../../patterns/serialization.js";
+
+/**
+ * Issue #279: a serializer producing zero bytes (e.g. JSON.stringify(undefined))
+ * made submit() crash with an opaque TypeError (`durable[0]` undefined), while
+ * write() threw a clear S2Error from AppendInput.create(). The fix rejects
+ * empty serializations in toRecords() so both paths throw the same S2Error.
+ */
+
+class FakeAppendSession {
+	submitCalls = 0;
+
+	async submit(): Promise<any> {
+		this.submitCalls += 1;
+		const ack = {
+			start: { seqNum: 0, timestamp: 0 },
+			end: { seqNum: 1, timestamp: 0 },
+			tail: { seqNum: 1, timestamp: 0 },
+		};
+		return { ack: async () => ack, bytes: 0, numRecords: 1 };
+	}
+
+	async close(): Promise<void> {}
+}
+
+const jsonSerializer = (value: unknown) =>
+	new TextEncoder().encode(JSON.stringify(value));
+
+describe("Issue #279: empty serialization throws S2Error instead of TypeError", () => {
+	it("submit() rejects with S2Error and submits nothing", async () => {
+		const fakeSession = new FakeAppendSession();
+		const session = new SerializingAppendSession<unknown>(
+			fakeSession as any,
+			jsonSerializer,
+		);
+
+		// JSON.stringify(undefined) === undefined -> encode() yields 0 bytes.
+		await expect(session.submit(undefined)).rejects.toThrow(S2Error);
+		expect(fakeSession.submitCalls).toBe(0);
+
+		// Session remains usable for valid messages.
+		await expect(session.submit({ ok: true })).resolves.toEqual({
+			start: 0,
+			end: 1,
+		});
+	});
+
+	it("write() rejects with the same S2Error", async () => {
+		const session = new SerializingAppendSession<unknown>(
+			new FakeAppendSession() as any,
+			jsonSerializer,
+		);
+		const writer = session.getWriter();
+
+		await expect(writer.write(undefined)).rejects.toThrow(S2Error);
+		await expect(writer.write(undefined)).rejects.toThrow(
+			"Serialized message is empty",
+		);
+	});
+});

--- a/packages/patterns/src/tests/reproductions/issue-279.test.ts
+++ b/packages/patterns/src/tests/reproductions/issue-279.test.ts
@@ -54,9 +54,8 @@ describe("Issue #279: empty serialization throws S2Error instead of TypeError", 
 		);
 		const writer = session.getWriter();
 
-		await expect(writer.write(undefined)).rejects.toThrow(S2Error);
-		await expect(writer.write(undefined)).rejects.toThrow(
-			"Serialized message is empty",
-		);
+		const err = await writer.write(undefined).catch((e) => e);
+		expect(err).toBeInstanceOf(S2Error);
+		expect(err.message).toContain("Serialized message is empty");
 	});
 });


### PR DESCRIPTION
Fixes #279

## Problem

A serializer producing zero bytes (e.g. `new TextEncoder().encode(JSON.stringify(undefined))`) made `SerializingAppendSession.submit()` crash with an opaque `TypeError: undefined is not an object (evaluating 'durable[0].start')`: `chunkBytes` returns `[]` for empty input, `frameChunksToRecords([])` returns `[]`, the submit loop never runs, and `durable[0]!` dereferences undefined. Meanwhile `write()` threw a clear `S2Error` for the same input via `AppendInput.create()`.

## Fix

Validate in `toRecords()` — the shared source of both paths — throwing an `S2Error` (`origin: "sdk"`) when the serialized message is empty. This goes slightly beyond the issue's suggested guard-in-`submit()`: both `write()` and `submit()` now throw the *same* error, and the message names the actual cause (the serializer produced zero bytes) rather than the downstream symptom ("AppendInput must contain at least one record"). An empty payload is unrepresentable in the framing protocol anyway (`FrameAssembler` rejects zero-byte frames on the read side), so rejecting at serialization time is the correct boundary.

## Testing

- Added `reproductions/issue-279.test.ts` covering both `submit()` (rejects with `S2Error`, nothing submitted, session stays usable) and `write()` (same `S2Error`).
- `bun run check` and the patterns unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)