### PR TITLE
fix: reject pre-existing dedupe headers in injectDedupeHeaders

### DIFF
--- a/.changeset/dedupe-header-collision.md
+++ b/.changeset/dedupe-header-collision.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore-patterns": patch
+---
+
+`injectDedupeHeaders` now throws a clear `S2Error` when a record already carries a reserved `_dedupe_seq` or `_writer_id` header, instead of silently appending duplicates. Previously the stale pre-existing header shadowed the injected sequence on the read side (readers pick the first match), corrupting dedupe filtering or crashing `decodeU64` on a malformed value. Validation runs before any record is mutated.

--- a/packages/patterns/src/patterns/dedupe.ts
+++ b/packages/patterns/src/patterns/dedupe.ts
@@ -3,9 +3,15 @@ import {
 	type AppendRecord,
 	meteredBytes,
 	type ReadHeaders,
+	S2Error,
 } from "@s2-dev/streamstore";
 
-import { DEDUPE_SEQ_HEADER_BYTES, DEDUPE_WRITER_UNIQ_ID } from "./constants.js";
+import {
+	DEDUPE_SEQ_HEADER,
+	DEDUPE_SEQ_HEADER_BYTES,
+	DEDUPE_WRITER_UNIQ_ID,
+	WRITER_UNIQ_ID,
+} from "./constants.js";
 import { decodeU64, encodeU64 } from "./u64.js";
 
 const textEncoder = new TextEncoder();
@@ -101,17 +107,60 @@ export class DedupeFilter {
 	}
 }
 
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i += 1) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
+}
+
+/** Return the name of a reserved dedupe header present in headers, if any. */
+function findReservedDedupeHeader(
+	headers: AppendHeaders<"string"> | AppendHeaders<"bytes"> | undefined,
+): string | undefined {
+	if (!headers) return undefined;
+	for (const [key] of headers as Array<[string | Uint8Array, unknown]>) {
+		if (typeof key === "string") {
+			if (key === DEDUPE_SEQ_HEADER) return DEDUPE_SEQ_HEADER;
+			if (key === WRITER_UNIQ_ID) return WRITER_UNIQ_ID;
+		} else {
+			if (bytesEqual(key, DEDUPE_SEQ_HEADER_BYTES)) return DEDUPE_SEQ_HEADER;
+			if (bytesEqual(key, DEDUPE_WRITER_UNIQ_ID)) return WRITER_UNIQ_ID;
+		}
+	}
+	return undefined;
+}
+
 /**
  * Inject a monotonically increasing dedupe sequence header into each record.
  *
  * Returns the next sequence number after the last record, so callers can
  * maintain state across multiple batches.
+ *
+ * @throws {S2Error} If a record already carries a reserved dedupe header
+ * (`_dedupe_seq` or `_writer_id`); no record is modified in that case.
  */
 export function injectDedupeHeaders(
 	records: AppendRecord[],
 	writerId: string,
 	startSeq: number,
 ): number {
+	for (const record of records) {
+		const reserved = findReservedDedupeHeader(
+			record.headers as
+				| AppendHeaders<"string">
+				| AppendHeaders<"bytes">
+				| undefined,
+		);
+		if (reserved !== undefined) {
+			throw new S2Error({
+				message: `Record already contains reserved dedupe header "${reserved}"; remove it or skip dedupe injection`,
+				origin: "sdk",
+			});
+		}
+	}
+
 	let seq = startSeq;
 
 	for (const record of records) {

--- a/packages/patterns/src/tests/reproductions/issue-278.test.ts
+++ b/packages/patterns/src/tests/reproductions/issue-278.test.ts
@@ -1,0 +1,75 @@
+import { AppendRecord, S2Error } from "@s2-dev/streamstore";
+import { describe, expect, it } from "vitest";
+import {
+	DEDUPE_SEQ_HEADER,
+	DEDUPE_SEQ_HEADER_BYTES,
+	WRITER_UNIQ_ID,
+} from "../../patterns/constants.js";
+import {
+	extractDedupeSeq,
+	injectDedupeHeaders,
+} from "../../patterns/dedupe.js";
+
+/**
+ * Issue #278: injectDedupeHeaders appended `_dedupe_seq`/`_writer_id` without
+ * checking for pre-existing ones. Since extractDedupeSeq returns the FIRST
+ * match, a stale pre-existing header shadowed the injected sequence (silent
+ * dedupe corruption) or crashed decodeU64 if not 8 bytes. The fix rejects
+ * records that already carry a reserved dedupe header, before mutating any.
+ */
+
+describe("Issue #278: injectDedupeHeaders rejects pre-existing dedupe headers", () => {
+	it("throws S2Error on an existing string _dedupe_seq header", () => {
+		const record = AppendRecord.string({
+			body: "hello",
+			headers: [[DEDUPE_SEQ_HEADER, "stale"]],
+		});
+		expect(() => injectDedupeHeaders([record], "writer-a", 0)).toThrow(S2Error);
+		expect(() => injectDedupeHeaders([record], "writer-a", 0)).toThrow(
+			DEDUPE_SEQ_HEADER,
+		);
+	});
+
+	it("throws S2Error on an existing string _writer_id header", () => {
+		const record = AppendRecord.string({
+			body: "hello",
+			headers: [[WRITER_UNIQ_ID, "other-writer"]],
+		});
+		expect(() => injectDedupeHeaders([record], "writer-a", 0)).toThrow(S2Error);
+	});
+
+	it("throws S2Error on an existing bytes _dedupe_seq header (double injection)", () => {
+		const record = AppendRecord.string({ body: "hello" });
+		const next = injectDedupeHeaders([record], "writer-a", 7);
+		expect(next).toBe(8);
+
+		// A second injection must not stack another _dedupe_seq behind the first.
+		expect(() => injectDedupeHeaders([record], "writer-a", next)).toThrow(
+			S2Error,
+		);
+		expect(extractDedupeSeq(record.headers as any)).toEqual(["writer-a", 7]);
+	});
+
+	it("modifies no record when a later record has a collision", () => {
+		const clean = AppendRecord.string({ body: "first" });
+		const dirty = AppendRecord.bytes({
+			body: new Uint8Array([1]),
+			headers: [[DEDUPE_SEQ_HEADER_BYTES, new Uint8Array(8)]],
+		});
+
+		expect(() => injectDedupeHeaders([clean, dirty], "writer-a", 0)).toThrow(
+			S2Error,
+		);
+		expect(extractDedupeSeq(clean.headers as any)).toBeUndefined();
+	});
+
+	it("still injects into records with unrelated headers", () => {
+		const record = AppendRecord.string({
+			body: "world",
+			headers: [["key", "val"]],
+		});
+		const next = injectDedupeHeaders([record], "writer-a", 42);
+		expect(next).toBe(43);
+		expect(extractDedupeSeq(record.headers as any)).toEqual(["writer-a", 42]);
+	});
+});


### PR DESCRIPTION
Fixes #278

## Problem

`injectDedupeHeaders` copied all existing headers and unconditionally appended `_dedupe_seq` and `_writer_id`. If a record already carried a dedupe header (double injection, or user-supplied records using the reserved names), the record ended up with duplicates — and since `extractDedupeSeq` returns the **first** match while injection appends to the **end**, the stale pre-existing header shadowed the injected sequence on the read side. Consequences: silent dedupe corruption (`DedupeFilter` can wrongly drop live records) or a `decodeU64` crash when the pre-existing value isn't 8 bytes. `injectDedupeHeaders` is exported public API, so this is reachable outside the internal `SerializingAppendSession` path (which always injects into freshly framed records and is unaffected).

## Fix

Validate every record up front — checking for reserved `_dedupe_seq`/`_writer_id` keys in both string and bytes form — and throw a descriptive `S2Error` (`origin: "sdk"`) before mutating anything, so a collision never leaves the batch half-injected.

## Testing

- Added `reproductions/issue-278.test.ts`: string and bytes collisions on both reserved headers, the double-injection case (verifying the original sequence is preserved and no duplicate is stacked), no-mutation-on-partial-failure, and that unrelated user headers still inject fine.
- `bun run check` and the full patterns unit suite (32 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)