### PR TITLE
fix: enable HTTP/2 transport on Deno >= 2.7.5

### DIFF
--- a/.changeset/deno-http2-enable.md
+++ b/.changeset/deno-http2-enable.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Enable the HTTP/2 (s2s) transport on Deno >= 2.7.5. Buffers response body chunks until headers arrive, working around Deno's `node:http2` emitting `data` before `response`; older Deno versions keep the fetch transport fallback.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ const stream = basin.stream(streamName, {
 ... or rely on environment auto-detection to specify the transport, as is the default behavior.
 
 > [!IMPORTANT]
-> HTTP/2 library use, required for `s2s`, is currently only enabled by default for Node.js. Bun defaults to HTTP/1 (see [tracking issue](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113)), but can be forced using the mechanism described above. Same with Deno ([issue](https://github.com/s2-streamstore/s2-sdk-typescript/issues/169)).
+> HTTP/2 library use, required for `s2s`, is enabled by default on Node.js, Bun >= 1.3.11, and Deno >= 2.7.5. Older Bun and Deno versions default to HTTP/1.1 due to `node:http2` bugs in those runtimes ([#113](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113), [#169](https://github.com/s2-streamstore/s2-sdk-typescript/issues/169)), but `s2s` can be forced using the mechanism described above.
 
 ## Patterns
 

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -56,10 +56,11 @@ export function supportsHttp2(): boolean {
 			return true;
 
 		case "deno":
-			// Deno's node:http2 has data-chunking differences that cause
-			// "premature EOF" errors in the s2s frame parser.
-			// Fall back to fetch transport until Deno's compat improves.
-			return false;
+			// Deno < 2.7.5 lacks ClientHttp2Stream._writev, which append sessions
+			// need (issue #169). The data-before-response event ordering on newer
+			// Deno is handled by chunk buffering in the s2s transport.
+			// @ts-expect-error - Deno global not in types
+			return versionAtLeast(Deno.version?.deno, "2.7.5");
 
 		case "bun":
 			// Bun < 1.3.11 never sends connection-level WINDOW_UPDATE frames, so
@@ -74,6 +75,19 @@ export function supportsHttp2(): boolean {
 		default:
 			return false;
 	}
+}
+
+function versionAtLeast(version: string | undefined, minimum: string): boolean {
+	if (!version) return false;
+	const actual = version.split("-")[0]?.split(".").map(Number) ?? [];
+	const wanted = minimum.split(".").map(Number);
+	for (let i = 0; i < wanted.length; i++) {
+		const a = actual[i] ?? 0;
+		const b = wanted[i] ?? 0;
+		if (Number.isNaN(a)) return false;
+		if (a !== b) return a > b;
+	}
+	return true;
 }
 
 /**

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -56,9 +56,7 @@ export function supportsHttp2(): boolean {
 			return true;
 
 		case "deno":
-			// Deno < 2.7.5 lacks ClientHttp2Stream._writev, which append sessions
-			// need (issue #169). The data-before-response event ordering on newer
-			// Deno is handled by chunk buffering in the s2s transport.
+			// Deno < 2.7.5 not supported
 			// @ts-expect-error - Deno global not in types
 			return versionAtLeast(Deno.version?.deno, "2.7.5");
 

--- a/packages/streamstore/src/lib/stream/runtime.ts
+++ b/packages/streamstore/src/lib/stream/runtime.ts
@@ -77,7 +77,8 @@ export function supportsHttp2(): boolean {
 
 function versionAtLeast(version: string | undefined, minimum: string): boolean {
 	if (!version) return false;
-	const actual = version.split("-")[0]?.split(".").map(Number) ?? [];
+	const [core, prerelease] = version.split("-");
+	const actual = core?.split(".").map(Number) ?? [];
 	const wanted = minimum.split(".").map(Number);
 	for (let i = 0; i < wanted.length; i++) {
 		const a = actual[i] ?? 0;
@@ -85,7 +86,8 @@ function versionAtLeast(version: string | undefined, minimum: string): boolean {
 		if (Number.isNaN(a)) return false;
 		if (a !== b) return a > b;
 	}
-	return true;
+	// A prerelease (e.g. 2.7.5-rc.1) precedes its stable release.
+	return prerelease === undefined;
 }
 
 /**

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -333,6 +333,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 			start: async (controller) => {
 				let controllerClosed = false;
 				let responseCode: number | undefined;
+				let pendingChunks: Buffer[] | undefined;
 
 				// Listener references for cleanup (issue #142)
 				let abortHandler: (() => void) | undefined;
@@ -463,6 +464,13 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 						// Cache the status.
 						// This informs whether we should attempt to parse s2s frames in the "data" handler.
 						responseCode = headers[":status"] ?? 500;
+						if (pendingChunks) {
+							const buffered = pendingChunks;
+							pendingChunks = undefined;
+							for (const chunk of buffered) {
+								processChunk(chunk);
+							}
+						}
 					});
 
 					sessionConnection = connection;
@@ -475,7 +483,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 						safeError(err);
 					});
 
-					stream.on("data", (chunk: Buffer) => {
+					const processChunk = (chunk: Buffer) => {
 						try {
 							const status = responseCode ?? 500;
 							if (status >= 400) {
@@ -633,6 +641,16 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 										}),
 							);
 						}
+					};
+
+					stream.on("data", (chunk: Buffer) => {
+						// Some runtimes (Deno >= 2.7.5) emit "data" before "response";
+						// buffer until the status is known so frames aren't misread as an error body.
+						if (responseCode === undefined) {
+							(pendingChunks ??= []).push(chunk);
+							return;
+						}
+						processChunk(chunk);
 					});
 
 					stream.on("end", () => {
@@ -650,7 +668,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					});
 
 					stream.on("close", () => {
-						if (parser.hasData()) {
+						if (pendingChunks || parser.hasData()) {
 							safeError(
 								new S2Error({
 									message: "Stream closed with unparsed data remaining",
@@ -851,6 +869,7 @@ class S2SAppendSession implements TransportAppendSession {
 
 		const textDecoder = new TextDecoder();
 		let responseCode: number | undefined;
+		let pendingChunks: Buffer[] | undefined;
 
 		const safeError = (error: unknown) => {
 			// Resolve all pending acks with error result
@@ -866,10 +885,17 @@ class S2SAppendSession implements TransportAppendSession {
 		// Capture HTTP response status
 		stream.on("response", (headers) => {
 			responseCode = headers[":status"] ?? 500;
+			if (pendingChunks) {
+				const buffered = pendingChunks;
+				pendingChunks = undefined;
+				for (const chunk of buffered) {
+					processChunk(chunk);
+				}
+			}
 		});
 
 		// Handle incoming data (acks or error response)
-		stream.on("data", (chunk: Buffer) => {
+		const processChunk = (chunk: Buffer) => {
 			try {
 				// Check for HTTP-level errors first (before s2s frame parsing)
 				if ((responseCode ?? 200) >= 400) {
@@ -959,6 +985,16 @@ class S2SAppendSession implements TransportAppendSession {
 			} catch (error) {
 				queueMicrotask(() => safeError(error));
 			}
+		};
+
+		stream.on("data", (chunk: Buffer) => {
+			// Some runtimes (Deno >= 2.7.5) emit "data" before "response";
+			// buffer until the status is known so an error body isn't parsed as acks.
+			if (responseCode === undefined) {
+				(pendingChunks ??= []).push(chunk);
+				return;
+			}
+			processChunk(chunk);
 		});
 
 		stream.on("error", (streamErr: Error) => {

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -644,8 +644,8 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					};
 
 					stream.on("data", (chunk: Buffer) => {
-						// Some runtimes (Deno >= 2.7.5) emit "data" before "response";
-						// buffer until the status is known so frames aren't misread as an error body.
+						// Deno >= 2.7.5 emits "data" before "response";
+						// buffer until the status is known so an error body isn't parsed as acks.
 						if (responseCode === undefined) {
 							(pendingChunks ??= []).push(chunk);
 							return;
@@ -988,7 +988,7 @@ class S2SAppendSession implements TransportAppendSession {
 		};
 
 		stream.on("data", (chunk: Buffer) => {
-			// Some runtimes (Deno >= 2.7.5) emit "data" before "response";
+			// Deno >= 2.7.5 emits "data" before "response";
 			// buffer until the status is known so an error body isn't parsed as acks.
 			if (responseCode === undefined) {
 				(pendingChunks ??= []).push(chunk);


### PR DESCRIPTION
Enables the s2s (HTTP/2) transport on Deno >= 2.7.5. Deno's `node:http2` client emits `data` before `response` when headers and body arrive in the same socket read (regression in the 2.7.5 http2 rewrite, denoland/deno#32418), so the read path misparsed s2s frames as an HTTP error body. Both session paths now buffer body chunks until the response status is known. Deno < 2.7.5 keeps the fetch fallback (`ClientHttp2Stream._writev` is not implemented there).

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)