### PR TITLE
feat: pool s2s HTTP/2 connections per endpoint

### DIFF
--- a/.changeset/h2-connection-pooling.md
+++ b/.changeset/h2-connection-pooling.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Pool HTTP/2 connections in the s2s transport: all streams targeting the same endpoint now share one connection, dialed lazily on the first request, instead of dialing one connection per `S2Stream` handle. Each connection carries up to 100 concurrent requests; beyond that, load spills over to additional connections. Connections are closed when the last stream handle using the endpoint is closed.

--- a/.changeset/h2-connection-pooling.md
+++ b/.changeset/h2-connection-pooling.md
@@ -2,4 +2,4 @@
 "@s2-dev/streamstore": patch
 ---
 
-Pool HTTP/2 connections in the s2s transport: all streams targeting the same endpoint now share one connection, dialed lazily on the first request, instead of dialing one connection per `S2Stream` handle. Each connection carries up to 100 concurrent requests; beyond that, load spills over to additional connections. Connections are closed when the last stream handle using the endpoint is closed.
+Pool HTTP/2 connections in the s2s transport: all streams targeting the same endpoint now share one connection, opened lazily on the first request, instead of one connection per `S2Stream` handle. Each connection carries up to 100 concurrent requests; beyond that, additional connections are opened. Connections are closed when the last stream handle using the endpoint is closed.

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -5,7 +5,8 @@
  * This file should only be imported in Node.js environments
  */
 
-import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
+import type { OutgoingHttpHeaders } from "node:http";
+import type { ClientHttp2Stream, Http2Session } from "node:http2";
 import createDebug from "debug";
 
 /** Type for ReadableStream with optional async iterator support. */
@@ -64,36 +65,28 @@ import {
 	frameMessage,
 	S2SFrameParser,
 } from "./framing.js";
+import { sharedConnectionPool } from "./pool.js";
 
 const debug = createDebug("s2:s2s");
 
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
-type Http2Module = typeof import("node:http2");
-
-let http2ModulePromise: Promise<Http2Module> | undefined;
-async function loadHttp2(): Promise<Http2Module> {
-	// Hint bundlers to skip bundling node:http2 while keeping the specifier static for type inference.
-	if (!http2ModulePromise) {
-		http2ModulePromise = import(
-			/* webpackIgnore: true */
-			/* @vite-ignore */
-			"node:http2"
-		);
-	}
-	return http2ModulePromise;
-}
+/** Opens an HTTP/2 stream to the transport's endpoint. */
+type OpenH2Stream = (
+	headers: OutgoingHttpHeaders,
+) => Promise<ClientHttp2Stream>;
 
 export class S2STransport implements SessionTransport {
 	private readonly transportConfig: TransportConfig;
 	private readonly compression: CompressionType;
-	private connection?: ClientHttp2Session;
-	private connectionPromise?: Promise<ClientHttp2Session>;
+	private readonly endpointOrigin: string;
+	private attached = false;
 	private closingPromise?: Promise<void>;
 
 	constructor(config: TransportConfig) {
 		this.transportConfig = config;
 		this.compression = config.compression ?? "none";
+		this.endpointOrigin = new URL(config.baseUrl).origin;
 	}
 
 	async makeAppendSession(
@@ -108,7 +101,7 @@ export class S2STransport implements SessionTransport {
 					this.transportConfig.baseUrl,
 					this.transportConfig.accessToken,
 					stream,
-					() => this.getConnection(),
+					(headers) => this.openH2Stream(headers),
 					this.transportConfig.basinName,
 					this.transportConfig.encryptionKey,
 					this.compression,
@@ -136,7 +129,7 @@ export class S2STransport implements SessionTransport {
 					stream,
 					myArgs,
 					options,
-					() => this.getConnection(),
+					(headers) => this.openH2Stream(headers),
 					this.transportConfig.basinName,
 					this.transportConfig.encryptionKey,
 					this.compression,
@@ -148,104 +141,17 @@ export class S2STransport implements SessionTransport {
 	}
 
 	/**
-	 * Get or create HTTP/2 connection (one per transport)
+	 * Open an HTTP/2 stream via the shared per-endpoint connection pool,
+	 * registering interest in the endpoint on first use.
 	 */
-	private async getConnection(): Promise<ClientHttp2Session> {
-		if (
-			this.connection &&
-			!this.connection.closed &&
-			!this.connection.destroyed
-		) {
-			return this.connection;
+	private openH2Stream(headers: OutgoingHttpHeaders) {
+		if (!this.attached) {
+			sharedConnectionPool.attach(this.endpointOrigin);
+			this.attached = true;
 		}
-
-		// If connection is in progress, wait for it
-		if (this.connectionPromise) {
-			return this.connectionPromise;
-		}
-
-		// Create new connection
-		this.connectionPromise = this.createConnection();
-
-		try {
-			this.connection = await this.connectionPromise;
-			return this.connection;
-		} finally {
-			this.connectionPromise = undefined;
-		}
-	}
-
-	private async createConnection(): Promise<ClientHttp2Session> {
-		const http2 = await loadHttp2();
-		const url = new URL(this.transportConfig.baseUrl);
-		const client = http2.connect(url.origin, {
-			// Use HTTPS settings
-			...(url.protocol === "https:"
-				? {
-						// TLS options can go here if needed
-					}
-				: {}),
-			settings: {
-				initialWindowSize: 10 * 1024 * 1024, // 10 MB
-			},
+		return sharedConnectionPool.request(this.endpointOrigin, headers, {
+			connectionTimeoutMillis: this.transportConfig.connectionTimeoutMillis,
 		});
-
-		const connectPromise = new Promise<ClientHttp2Session>(
-			(resolve, reject) => {
-				client.once("connect", () => {
-					// Guard against session being destroyed before connect fires
-					if (client.destroyed) return;
-					try {
-						client.setLocalWindowSize(10 * 1024 * 1024);
-					} catch {
-						// Not implemented in all runtimes (e.g. Deno).
-						// This is a performance optimization, not required for correctness.
-					}
-					resolve(client);
-				});
-
-				client.once("error", (err) => {
-					reject(err);
-				});
-
-				// Handle connection close
-				client.once("close", () => {
-					if (this.connection === client) {
-						this.connection = undefined;
-					}
-				});
-			},
-		);
-
-		// Apply connection timeout if configured
-		const connectionTimeout =
-			this.transportConfig.connectionTimeoutMillis ?? 3000;
-
-		let timeoutId: NodeJS.Timeout | undefined;
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			timeoutId = setTimeout(() => {
-				// Destroy the client on timeout
-				if (!client.closed && !client.destroyed) {
-					client.destroy();
-				}
-				reject(
-					new S2Error({
-						message: `Connection timeout after ${connectionTimeout}ms`,
-						status: 408,
-						code: "CONNECTION_TIMEOUT",
-						origin: "sdk",
-					}),
-				);
-			}, connectionTimeout);
-		});
-
-		try {
-			return await Promise.race([connectPromise, timeoutPromise]);
-		} finally {
-			if (timeoutId) {
-				clearTimeout(timeoutId);
-			}
-		}
 	}
 
 	async close(): Promise<void> {
@@ -254,15 +160,10 @@ export class S2STransport implements SessionTransport {
 		}
 
 		this.closingPromise = (async () => {
-			const connection =
-				this.connection ??
-				(await this.connectionPromise?.catch(() => undefined));
-			if (connection && !connection.closed && !connection.destroyed) {
-				await new Promise<void>((resolve) => {
-					connection.close(() => resolve());
-				});
+			if (this.attached) {
+				this.attached = false;
+				await sharedConnectionPool.detach(this.endpointOrigin);
 			}
-			this.connection = undefined;
 		})();
 
 		try {
@@ -289,7 +190,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		streamName: string,
 		args: ReadArgs<Format> | undefined,
 		options: S2RequestOptions | undefined,
-		getConnection: () => Promise<ClientHttp2Session>,
+		openH2Stream: OpenH2Stream,
 		basinName?: string,
 		encryptionKey?: Redacted.Redacted<string>,
 		compression: CompressionType = "none",
@@ -301,7 +202,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 			bearerToken,
 			url,
 			options,
-			getConnection,
+			openH2Stream,
 			basinName,
 			encryptionKey,
 			compression,
@@ -314,7 +215,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		private authToken: Redacted.Redacted,
 		private url: URL,
 		private options: S2RequestOptions | undefined,
-		private getConnection: () => Promise<ClientHttp2Session>,
+		private openH2Stream: OpenH2Stream,
 		private basinName?: string,
 		private encryptionKey?: Redacted.Redacted<string>,
 		private compression: CompressionType = "none",
@@ -344,7 +245,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 							opaqueData: Buffer,
 					  ) => void)
 					| undefined;
-				let sessionConnection: ClientHttp2Session | undefined;
+				let sessionConnection: Http2Session | undefined;
 
 				const cleanupListeners = () => {
 					if (abortHandler && options?.signal) {
@@ -407,7 +308,6 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 				try {
 					// Start the timeout timer - will fire in 20s if no tail received
 					resetTimeoutTimer();
-					const connection = await getConnection();
 
 					// Build query string
 					const queryParams = new URLSearchParams();
@@ -433,7 +333,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					const path = `${url.pathname}/streams/${encodeURIComponent(streamName)}/records${queryString ? `?${queryString}` : ""}`;
 
 					const acceptEncoding = await acceptEncodingHeader(compression);
-					const stream = connection.request({
+					const stream = await openH2Stream({
 						":method": "GET",
 						":path": path,
 						":scheme": url.protocol.slice(0, -1),
@@ -473,11 +373,11 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 						}
 					});
 
-					sessionConnection = connection;
+					sessionConnection = stream.session;
 					goawayHandler = (errorCode, lastStreamID, opaqueData) => {
 						debug("received GOAWAY from server");
 					};
-					connection.on("goaway", goawayHandler);
+					sessionConnection?.on("goaway", goawayHandler);
 
 					stream.on("error", (err) => {
 						safeError(err);
@@ -799,7 +699,7 @@ class S2SAppendSession implements TransportAppendSession {
 		baseUrl: string,
 		bearerToken: Redacted.Redacted,
 		streamName: string,
-		getConnection: () => Promise<ClientHttp2Session>,
+		openH2Stream: OpenH2Stream,
 		basinName: string | undefined,
 		encryptionKey: Redacted.Redacted<string> | undefined,
 		compression: CompressionType,
@@ -810,7 +710,7 @@ class S2SAppendSession implements TransportAppendSession {
 			baseUrl,
 			bearerToken,
 			streamName,
-			getConnection,
+			openH2Stream,
 			basinName,
 			encryptionKey,
 			compression,
@@ -823,7 +723,7 @@ class S2SAppendSession implements TransportAppendSession {
 		private baseUrl: string,
 		private authToken: Redacted.Redacted,
 		private streamName: string,
-		private getConnection: () => Promise<ClientHttp2Session>,
+		private openH2Stream: OpenH2Stream,
 		private basinName: string | undefined,
 		private encryptionKey: Redacted.Redacted<string> | undefined,
 		private compression: CompressionType,
@@ -836,12 +736,11 @@ class S2SAppendSession implements TransportAppendSession {
 
 	private async initializeStream(): Promise<void> {
 		const url = new URL(this.baseUrl);
-		const connection = await this.getConnection();
 
 		const path = `${url.pathname}/streams/${encodeURIComponent(this.streamName)}/records`;
 
 		const acceptEncoding = await acceptEncodingHeader(this.compression);
-		const stream = connection.request({
+		const stream = await this.openH2Stream({
 			":method": "POST",
 			":path": path,
 			":scheme": url.protocol.slice(0, -1),

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -140,10 +140,7 @@ export class S2STransport implements SessionTransport {
 		);
 	}
 
-	/**
-	 * Open an HTTP/2 stream via the shared per-endpoint connection pool,
-	 * registering interest in the endpoint on first use.
-	 */
+	/** Open an HTTP/2 stream through the shared connection pool. */
 	private openH2Stream(headers: OutgoingHttpHeaders) {
 		if (!this.attached) {
 			sharedConnectionPool.attach(this.endpointOrigin);

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -81,6 +81,7 @@ export class S2STransport implements SessionTransport {
 	private readonly compression: CompressionType;
 	private readonly endpointOrigin: string;
 	private attached = false;
+	private closed = false;
 	private closingPromise?: Promise<void>;
 
 	constructor(config: TransportConfig) {
@@ -142,6 +143,14 @@ export class S2STransport implements SessionTransport {
 
 	/** Open an HTTP/2 stream through the shared connection pool. */
 	private openH2Stream(headers: OutgoingHttpHeaders) {
+		// Retries may fire after close(); re-attaching then would leak the pool entry.
+		if (this.closed) {
+			throw new S2Error({
+				message: "S2STransport is closed",
+				status: 400,
+				origin: "sdk",
+			});
+		}
 		if (!this.attached) {
 			sharedConnectionPool.attach(this.endpointOrigin);
 			this.attached = true;
@@ -152,6 +161,7 @@ export class S2STransport implements SessionTransport {
 	}
 
 	async close(): Promise<void> {
+		this.closed = true;
 		if (this.closingPromise) {
 			return this.closingPromise;
 		}

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -194,10 +194,14 @@ export class Http2ConnectionPool {
 		endpoint: Endpoint,
 		options?: RequestStreamOptions,
 	): PendingConnection {
-		const pending = { reservations: 0 } as PendingConnection;
+		const connectPromise = this.connect(origin, options);
+		const pending: PendingConnection = {
+			reservations: 0,
+			promise: connectPromise,
+		};
 		pending.promise = (async () => {
 			try {
-				const connection = await this.connect(origin, options);
+				const connection = await connectPromise;
 				// Count reservations up front so requests arriving between now
 				// and the reserved openStream calls cannot oversubscribe it.
 				connection.activeStreams = pending.reservations;

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -13,7 +13,7 @@ import { S2Error } from "../../../../error.js";
 
 const debug = createDebug("s2:s2s:pool");
 
-export const MAX_CONCURRENT_STREAMS_PER_CONNECTION = 100;
+const MAX_CONCURRENT_STREAMS_PER_CONNECTION = 100;
 const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
 const INITIAL_WINDOW_SIZE = 10 * 1024 * 1024; // 10 MiB
 
@@ -35,6 +35,7 @@ async function loadHttp2(): Promise<Http2Module> {
 interface PooledConnection {
 	session: ClientHttp2Session;
 	activeStreams: number;
+	dead: boolean;
 }
 
 interface PendingConnection {
@@ -48,7 +49,7 @@ interface Endpoint {
 	pending: PendingConnection[];
 }
 
-export interface RequestStreamOptions {
+interface RequestStreamOptions {
 	connectionTimeoutMillis?: number;
 }
 
@@ -132,10 +133,7 @@ export class Http2ConnectionPool {
 			}
 
 			const usable = endpoint.connections.find(
-				(c) =>
-					!c.session.closed &&
-					!c.session.destroyed &&
-					c.activeStreams < this.maxStreamsPerConnection,
+				(c) => !c.dead && c.activeStreams < this.maxStreamsPerConnection,
 			);
 			if (usable) {
 				return this.openStream(usable, headers);
@@ -150,10 +148,11 @@ export class Http2ConnectionPool {
 			}
 			pending.reservations += 1;
 			const connection = await pending.promise;
-			if (connection.session.closed || connection.session.destroyed) {
+			if (connection.dead) {
 				continue;
 			}
-			return this.openStream(connection, headers);
+			// The reservation was already counted into activeStreams on connect.
+			return this.openStream(connection, headers, { reserved: true });
 		}
 		throw new S2Error({
 			message: `HTTP/2 connections to ${origin} closed repeatedly before use`,
@@ -170,9 +169,20 @@ export class Http2ConnectionPool {
 	private openStream(
 		connection: PooledConnection,
 		headers: OutgoingHttpHeaders,
+		opts?: { reserved: boolean },
 	): ClientHttp2Stream {
-		const stream = connection.session.request(headers);
-		connection.activeStreams += 1;
+		let stream: ClientHttp2Stream;
+		try {
+			stream = connection.session.request(headers);
+		} catch (err) {
+			if (opts?.reserved) {
+				connection.activeStreams -= 1;
+			}
+			throw err;
+		}
+		if (!opts?.reserved) {
+			connection.activeStreams += 1;
+		}
 		stream.once("close", () => {
 			connection.activeStreams -= 1;
 		});
@@ -188,7 +198,12 @@ export class Http2ConnectionPool {
 		pending.promise = (async () => {
 			try {
 				const connection = await this.connect(origin, options);
-				endpoint.connections.push(connection);
+				// Count reservations up front so requests arriving between now
+				// and the reserved openStream calls cannot oversubscribe it.
+				connection.activeStreams = pending.reservations;
+				if (!connection.dead) {
+					endpoint.connections.push(connection);
+				}
 				return connection;
 			} finally {
 				removeFrom(endpoint.pending, pending);
@@ -217,7 +232,11 @@ export class Http2ConnectionPool {
 			// Not available in every runtime.
 		}
 
-		const connection: PooledConnection = { session, activeStreams: 0 };
+		const connection: PooledConnection = {
+			session,
+			activeStreams: 0,
+			dead: false,
+		};
 
 		const connectPromise = new Promise<PooledConnection>((resolve, reject) => {
 			session.once("connect", () => {
@@ -270,11 +289,17 @@ export class Http2ConnectionPool {
 	}
 
 	private evict(origin: string, connection: PooledConnection): void {
+		connection.dead = true;
 		const endpoint = this.endpoints.get(origin);
-		if (!endpoint) {
-			return;
+		if (endpoint) {
+			removeFrom(endpoint.connections, connection);
 		}
-		removeFrom(endpoint.connections, connection);
+		// The pool loses track of the connection here, so make sure it winds
+		// down instead of relying on the server to close it.
+		const { session } = connection;
+		if (!session.closed && !session.destroyed) {
+			session.close();
+		}
 	}
 }
 

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -1,0 +1,296 @@
+/**
+ * Shared HTTP/2 connection pool for the s2s transport.
+ *
+ * One connection per endpoint origin, dialed lazily on the first request.
+ * Each connection carries up to `maxConcurrentStreamsPerConnection`
+ * concurrent streams; excess load spills over to additional connections.
+ */
+
+import type { OutgoingHttpHeaders } from "node:http";
+import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
+import createDebug from "debug";
+import { S2Error } from "../../../../error.js";
+
+const debug = createDebug("s2:s2s:pool");
+
+export const MAX_CONCURRENT_STREAMS_PER_CONNECTION = 100;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
+const INITIAL_WINDOW_SIZE = 10 * 1024 * 1024; // 10 MiB
+
+type Http2Module = typeof import("node:http2");
+
+let http2ModulePromise: Promise<Http2Module> | undefined;
+async function loadHttp2(): Promise<Http2Module> {
+	// Hint bundlers to skip bundling node:http2 while keeping the specifier static for type inference.
+	if (!http2ModulePromise) {
+		http2ModulePromise = import(
+			/* webpackIgnore: true */
+			/* @vite-ignore */
+			"node:http2"
+		);
+	}
+	return http2ModulePromise;
+}
+
+interface PooledConnection {
+	session: ClientHttp2Session;
+	activeStreams: number;
+}
+
+interface PendingConnection {
+	promise: Promise<PooledConnection>;
+	reservations: number;
+}
+
+interface Endpoint {
+	refCount: number;
+	connections: PooledConnection[];
+	pending: PendingConnection[];
+}
+
+export interface RequestStreamOptions {
+	connectionTimeoutMillis?: number;
+}
+
+export class Http2ConnectionPool {
+	private readonly endpoints = new Map<string, Endpoint>();
+	private readonly maxStreamsPerConnection: number;
+
+	constructor(options?: { maxConcurrentStreamsPerConnection?: number }) {
+		this.maxStreamsPerConnection =
+			options?.maxConcurrentStreamsPerConnection ??
+			MAX_CONCURRENT_STREAMS_PER_CONNECTION;
+	}
+
+	/**
+	 * Register interest in an endpoint. Must be paired with a `detach` call;
+	 * connections are shared by all attached users and closed on last detach.
+	 */
+	attach(origin: string): void {
+		const endpoint = this.endpoints.get(origin);
+		if (endpoint) {
+			endpoint.refCount += 1;
+		} else {
+			this.endpoints.set(origin, { refCount: 1, connections: [], pending: [] });
+		}
+	}
+
+	/**
+	 * Release interest in an endpoint. When the last user detaches, all
+	 * connections to the endpoint are closed gracefully.
+	 */
+	async detach(origin: string): Promise<void> {
+		const endpoint = this.endpoints.get(origin);
+		if (!endpoint) {
+			return;
+		}
+		endpoint.refCount -= 1;
+		if (endpoint.refCount > 0) {
+			return;
+		}
+		this.endpoints.delete(origin);
+
+		// Settle in-flight dials first; on success they land in `connections`.
+		await Promise.all(
+			endpoint.pending.map((p) => p.promise.catch(() => undefined)),
+		);
+		debug(
+			"closing %d connection(s) to %s",
+			endpoint.connections.length,
+			origin,
+		);
+		await Promise.all(
+			endpoint.connections.map((connection) => {
+				const { session } = connection;
+				if (session.closed || session.destroyed) {
+					return undefined;
+				}
+				return new Promise<void>((resolve) => {
+					session.close(() => resolve());
+				});
+			}),
+		);
+	}
+
+	/**
+	 * Open a new HTTP/2 stream to the endpoint, reusing a pooled connection
+	 * with spare capacity or dialing a new one. Requires a prior `attach`.
+	 */
+	async request(
+		origin: string,
+		headers: OutgoingHttpHeaders,
+		options?: RequestStreamOptions,
+	): Promise<ClientHttp2Stream> {
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const endpoint = this.endpoints.get(origin);
+			if (!endpoint) {
+				throw new S2Error({
+					message: `HTTP/2 connection pool is not attached to ${origin}`,
+					status: 500,
+					origin: "sdk",
+				});
+			}
+
+			const usable = endpoint.connections.find(
+				(c) =>
+					!c.session.closed &&
+					!c.session.destroyed &&
+					c.activeStreams < this.maxStreamsPerConnection,
+			);
+			if (usable) {
+				return this.openStream(usable, headers);
+			}
+
+			// Coalesce onto an in-flight dial unless its capacity is spoken for.
+			let pending = endpoint.pending.find(
+				(p) => p.reservations < this.maxStreamsPerConnection,
+			);
+			if (!pending) {
+				pending = this.startDial(origin, endpoint, options);
+			}
+			pending.reservations += 1;
+			const connection = await pending.promise;
+			if (connection.session.closed || connection.session.destroyed) {
+				continue;
+			}
+			return this.openStream(connection, headers);
+		}
+		throw new S2Error({
+			message: `HTTP/2 connections to ${origin} closed repeatedly before use`,
+			status: 500,
+			origin: "sdk",
+		});
+	}
+
+	/** Number of live pooled connections to an endpoint. */
+	connectionCount(origin: string): number {
+		return this.endpoints.get(origin)?.connections.length ?? 0;
+	}
+
+	private openStream(
+		connection: PooledConnection,
+		headers: OutgoingHttpHeaders,
+	): ClientHttp2Stream {
+		const stream = connection.session.request(headers);
+		connection.activeStreams += 1;
+		stream.once("close", () => {
+			connection.activeStreams -= 1;
+		});
+		return stream;
+	}
+
+	private startDial(
+		origin: string,
+		endpoint: Endpoint,
+		options?: RequestStreamOptions,
+	): PendingConnection {
+		const pending: PendingConnection = {
+			reservations: 0,
+			promise: undefined as unknown as Promise<PooledConnection>,
+		};
+		pending.promise = this.dial(origin, options).then(
+			(connection) => {
+				removeFrom(endpoint.pending, pending);
+				endpoint.connections.push(connection);
+				return connection;
+			},
+			(err) => {
+				removeFrom(endpoint.pending, pending);
+				throw err;
+			},
+		);
+		endpoint.pending.push(pending);
+		return pending;
+	}
+
+	private async dial(
+		origin: string,
+		options?: RequestStreamOptions,
+	): Promise<PooledConnection> {
+		debug("dialing %s", origin);
+		const http2 = await loadHttp2();
+		const session = http2.connect(origin, {
+			settings: {
+				initialWindowSize: INITIAL_WINDOW_SIZE,
+			},
+		});
+
+		try {
+			// Pooled streams add per-request session listeners (e.g. goaway).
+			session.setMaxListeners(0);
+		} catch {
+			// EventEmitter shims in some runtimes may not implement this.
+		}
+
+		const connection: PooledConnection = { session, activeStreams: 0 };
+
+		const connectPromise = new Promise<PooledConnection>((resolve, reject) => {
+			session.once("connect", () => {
+				// Guard against session being destroyed before connect fires
+				if (session.destroyed) return;
+				try {
+					session.setLocalWindowSize(INITIAL_WINDOW_SIZE);
+				} catch {
+					// Not implemented in all runtimes (e.g. Deno).
+					// This is a performance optimization, not required for correctness.
+				}
+				resolve(connection);
+			});
+			session.once("error", (err) => {
+				reject(err);
+			});
+		});
+
+		// Stop routing new streams to sessions that are going away.
+		// Session-level errors surface on their individual streams.
+		session.on("goaway", () => this.evict(origin, connection));
+		session.on("close", () => this.evict(origin, connection));
+		session.on("error", () => this.evict(origin, connection));
+
+		const connectionTimeout =
+			options?.connectionTimeoutMillis ?? DEFAULT_CONNECTION_TIMEOUT_MS;
+
+		let timeoutId: NodeJS.Timeout | undefined;
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeoutId = setTimeout(() => {
+				if (!session.closed && !session.destroyed) {
+					session.destroy();
+				}
+				reject(
+					new S2Error({
+						message: `Connection timeout after ${connectionTimeout}ms`,
+						status: 408,
+						code: "CONNECTION_TIMEOUT",
+						origin: "sdk",
+					}),
+				);
+			}, connectionTimeout);
+		});
+
+		try {
+			return await Promise.race([connectPromise, timeoutPromise]);
+		} finally {
+			if (timeoutId) {
+				clearTimeout(timeoutId);
+			}
+		}
+	}
+
+	private evict(origin: string, connection: PooledConnection): void {
+		const endpoint = this.endpoints.get(origin);
+		if (!endpoint) {
+			return;
+		}
+		removeFrom(endpoint.connections, connection);
+	}
+}
+
+function removeFrom<T>(list: T[], item: T): void {
+	const index = list.indexOf(item);
+	if (index !== -1) {
+		list.splice(index, 1);
+	}
+}
+
+/** Process-wide pool shared by all s2s transports. */
+export const sharedConnectionPool = new Http2ConnectionPool();

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -1,9 +1,9 @@
 /**
  * Shared HTTP/2 connection pool for the s2s transport.
  *
- * One connection per endpoint origin, dialed lazily on the first request.
- * Each connection carries up to `maxConcurrentStreamsPerConnection`
- * concurrent streams; excess load spills over to additional connections.
+ * One connection per endpoint, opened lazily on the first request. Each
+ * connection carries up to `maxConcurrentStreamsPerConnection` concurrent
+ * streams; beyond that, additional connections are opened.
  */
 
 import type { OutgoingHttpHeaders } from "node:http";
@@ -63,7 +63,7 @@ export class Http2ConnectionPool {
 	}
 
 	/**
-	 * Register interest in an endpoint. Must be paired with a `detach` call;
+	 * Register as a user of an endpoint. Must be paired with a `detach` call;
 	 * connections are shared by all attached users and closed on last detach.
 	 */
 	attach(origin: string): void {
@@ -76,8 +76,8 @@ export class Http2ConnectionPool {
 	}
 
 	/**
-	 * Release interest in an endpoint. When the last user detaches, all
-	 * connections to the endpoint are closed gracefully.
+	 * The inverse of `attach`. When the last user detaches, all connections
+	 * to the endpoint are closed gracefully.
 	 */
 	async detach(origin: string): Promise<void> {
 		const endpoint = this.endpoints.get(origin);
@@ -90,7 +90,7 @@ export class Http2ConnectionPool {
 		}
 		this.endpoints.delete(origin);
 
-		// Settle in-flight dials first; on success they land in `connections`.
+		// Wait for in-progress connects; successful ones land in `connections`.
 		await Promise.all(
 			endpoint.pending.map((p) => p.promise.catch(() => undefined)),
 		);
@@ -114,7 +114,7 @@ export class Http2ConnectionPool {
 
 	/**
 	 * Open a new HTTP/2 stream to the endpoint, reusing a pooled connection
-	 * with spare capacity or dialing a new one. Requires a prior `attach`.
+	 * with spare capacity or opening a new one. Requires a prior `attach`.
 	 */
 	async request(
 		origin: string,
@@ -141,12 +141,12 @@ export class Http2ConnectionPool {
 				return this.openStream(usable, headers);
 			}
 
-			// Coalesce onto an in-flight dial unless its capacity is spoken for.
+			// Join an in-progress connect if it still has room for this stream.
 			let pending = endpoint.pending.find(
 				(p) => p.reservations < this.maxStreamsPerConnection,
 			);
 			if (!pending) {
-				pending = this.startDial(origin, endpoint, options);
+				pending = this.startConnect(origin, endpoint, options);
 			}
 			pending.reservations += 1;
 			const connection = await pending.promise;
@@ -179,35 +179,30 @@ export class Http2ConnectionPool {
 		return stream;
 	}
 
-	private startDial(
+	private startConnect(
 		origin: string,
 		endpoint: Endpoint,
 		options?: RequestStreamOptions,
 	): PendingConnection {
-		const pending: PendingConnection = {
-			reservations: 0,
-			promise: undefined as unknown as Promise<PooledConnection>,
-		};
-		pending.promise = this.dial(origin, options).then(
-			(connection) => {
-				removeFrom(endpoint.pending, pending);
+		const pending = { reservations: 0 } as PendingConnection;
+		pending.promise = (async () => {
+			try {
+				const connection = await this.connect(origin, options);
 				endpoint.connections.push(connection);
 				return connection;
-			},
-			(err) => {
+			} finally {
 				removeFrom(endpoint.pending, pending);
-				throw err;
-			},
-		);
+			}
+		})();
 		endpoint.pending.push(pending);
 		return pending;
 	}
 
-	private async dial(
+	private async connect(
 		origin: string,
 		options?: RequestStreamOptions,
 	): Promise<PooledConnection> {
-		debug("dialing %s", origin);
+		debug("connecting to %s", origin);
 		const http2 = await loadHttp2();
 		const session = http2.connect(origin, {
 			settings: {
@@ -216,23 +211,21 @@ export class Http2ConnectionPool {
 		});
 
 		try {
-			// Pooled streams add per-request session listeners (e.g. goaway).
+			// Each pooled stream may add its own session listeners (e.g. goaway).
 			session.setMaxListeners(0);
 		} catch {
-			// EventEmitter shims in some runtimes may not implement this.
+			// Not available in every runtime.
 		}
 
 		const connection: PooledConnection = { session, activeStreams: 0 };
 
 		const connectPromise = new Promise<PooledConnection>((resolve, reject) => {
 			session.once("connect", () => {
-				// Guard against session being destroyed before connect fires
 				if (session.destroyed) return;
 				try {
 					session.setLocalWindowSize(INITIAL_WINDOW_SIZE);
 				} catch {
-					// Not implemented in all runtimes (e.g. Deno).
-					// This is a performance optimization, not required for correctness.
+					// Not available in every runtime; performance-only.
 				}
 				resolve(connection);
 			});
@@ -241,8 +234,8 @@ export class Http2ConnectionPool {
 			});
 		});
 
-		// Stop routing new streams to sessions that are going away.
-		// Session-level errors surface on their individual streams.
+		// A connection that errors or shuts down should get no new streams.
+		// Its open streams observe the failure through their own events.
 		session.on("goaway", () => this.evict(origin, connection));
 		session.on("close", () => this.evict(origin, connection));
 		session.on("error", () => this.evict(origin, connection));

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -8,6 +8,7 @@ import * as Redacted from "../lib/redacted.js";
 import { frameMessage } from "../lib/stream/transport/s2s/framing.js";
 import { S2STransport } from "../lib/stream/transport/s2s/index.js";
 import { Http2ConnectionPool } from "../lib/stream/transport/s2s/pool.js";
+import { sleep } from "./helpers.js";
 
 const TEST_TIMEOUT_MS = 15_000;
 
@@ -88,8 +89,6 @@ async function waitFor(
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const GET_HEADERS = { ":method": "GET", ":path": "/" };
 
@@ -223,6 +222,33 @@ describe("Http2ConnectionPool", () => {
 	);
 
 	it(
+		"evicts a connection on goaway and opens a new one",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+
+			pool.attach(server.origin);
+			const first = await pool.request(server.origin, GET_HEADERS);
+			first.on("error", () => {});
+			await waitFor(() => server.sessionCount() === 1);
+
+			for (const session of server.openSessions()) {
+				session.goaway();
+			}
+			await waitFor(() => pool.connectionCount(server.origin) === 0);
+
+			const second = await pool.request(server.origin, GET_HEADERS);
+			await waitFor(() => server.sessionCount() === 2);
+
+			first.close();
+			second.close();
+			server.endAllStreams();
+			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"replaces a connection that died on the next request",
 		async () => {
 			const server = await newServer();
@@ -296,6 +322,11 @@ describe("S2STransport connection sharing", () => {
 
 				await transport2.close();
 				await waitFor(() => server.openSessions().size === 0);
+
+				// A closed transport must not re-attach to the pool.
+				await expect(drain(transport2)).rejects.toThrow(/closed/);
+				await sleep(50);
+				expect(server.openSessions().size).toBe(0);
 			} finally {
 				await server.close().catch(() => {});
 			}

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -279,7 +279,7 @@ describe("S2STransport connection sharing", () => {
 	it(
 		"shares one connection across transports and closes it on last close",
 		async () => {
-			// Speak just enough s2s: a terminal frame with status 200 ends a read cleanly.
+			// The server replies with a terminal s2s frame (status 200), which ends a read session cleanly.
 			const server = await startServer((stream) => {
 				stream.end(
 					Buffer.from(

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -21,8 +21,8 @@ interface TestServer {
 }
 
 /**
- * Plaintext (h2c) HTTP/2 server that responds 200 and holds streams open
- * until endAllStreams() is called, so client-side stream counts stay stable.
+ * Plaintext HTTP/2 server that responds 200 and holds streams open
+ * until endAllStreams() is called.
  */
 async function startServer(
 	onStream?: (stream: ServerHttp2Stream) => void,
@@ -182,15 +182,12 @@ describe("Http2ConnectionPool", () => {
 			await sleep(50);
 			expect(server.sessionCount()).toBe(2);
 
-			// Freed capacity is reused instead of dialing again.
+			// Freed capacity is reused instead of opening a third connection.
 			for (const stream of streams) {
 				stream.close();
 			}
 			server.endAllStreams();
-			await waitFor(() => {
-				// All client streams closed; both connections have spare capacity.
-				return streams.every((s) => s.closed);
-			});
+			await waitFor(() => streams.every((s) => s.closed));
 			const reused = await pool.request(server.origin, GET_HEADERS);
 			await sleep(50);
 			expect(server.sessionCount()).toBe(2);

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -1,0 +1,308 @@
+import http2, {
+	type ServerHttp2Session,
+	type ServerHttp2Stream,
+} from "node:http2";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import * as Redacted from "../lib/redacted.js";
+import { frameMessage } from "../lib/stream/transport/s2s/framing.js";
+import { S2STransport } from "../lib/stream/transport/s2s/index.js";
+import { Http2ConnectionPool } from "../lib/stream/transport/s2s/pool.js";
+
+const TEST_TIMEOUT_MS = 15_000;
+
+interface TestServer {
+	origin: string;
+	sessionCount: () => number;
+	openSessions: () => Set<ServerHttp2Session>;
+	heldStreams: ServerHttp2Stream[];
+	endAllStreams: () => void;
+	close: () => Promise<void>;
+}
+
+/**
+ * Plaintext (h2c) HTTP/2 server that responds 200 and holds streams open
+ * until endAllStreams() is called, so client-side stream counts stay stable.
+ */
+async function startServer(
+	onStream?: (stream: ServerHttp2Stream) => void,
+): Promise<TestServer> {
+	const server = http2.createServer();
+	const sessions = new Set<ServerHttp2Session>();
+	let sessionCount = 0;
+	const heldStreams: ServerHttp2Stream[] = [];
+
+	server.on("sessionError", () => {});
+	server.on("session", (session) => {
+		sessionCount += 1;
+		sessions.add(session);
+		session.on("error", () => {});
+		session.on("close", () => sessions.delete(session));
+	});
+	server.on("stream", (stream) => {
+		stream.on("error", () => {});
+		stream.respond({ ":status": 200 });
+		if (onStream) {
+			onStream(stream);
+		} else {
+			heldStreams.push(stream);
+		}
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const port = (server.address() as AddressInfo).port;
+
+	return {
+		origin: `http://127.0.0.1:${port}`,
+		sessionCount: () => sessionCount,
+		openSessions: () => sessions,
+		heldStreams,
+		endAllStreams: () => {
+			for (const stream of heldStreams.splice(0)) {
+				try {
+					stream.end();
+				} catch {}
+			}
+		},
+		close: () =>
+			new Promise<void>((resolve) => {
+				for (const session of sessions) {
+					session.destroy();
+				}
+				server.close(() => resolve());
+			}),
+	};
+}
+
+async function waitFor(
+	condition: () => boolean,
+	timeoutMs = 5000,
+): Promise<void> {
+	const start = Date.now();
+	while (!condition()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("condition not met in time");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const GET_HEADERS = { ":method": "GET", ":path": "/" };
+
+describe("Http2ConnectionPool", () => {
+	const servers: TestServer[] = [];
+
+	afterEach(async () => {
+		await Promise.all(servers.splice(0).map((s) => s.close().catch(() => {})));
+	});
+
+	async function newServer(onStream?: (stream: ServerHttp2Stream) => void) {
+		const server = await startServer(onStream);
+		servers.push(server);
+		return server;
+	}
+
+	it(
+		"does not dial until the first request",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+
+			pool.attach(server.origin);
+			await sleep(50);
+			expect(server.sessionCount()).toBe(0);
+
+			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"rejects requests for endpoints that were never attached",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+
+			await expect(pool.request(server.origin, GET_HEADERS)).rejects.toThrow(
+				/not attached/,
+			);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"coalesces concurrent requests onto a single connection within the cap",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool({
+				maxConcurrentStreamsPerConnection: 2,
+			});
+
+			pool.attach(server.origin);
+			const [s1, s2] = await Promise.all([
+				pool.request(server.origin, GET_HEADERS),
+				pool.request(server.origin, GET_HEADERS),
+			]);
+
+			expect(pool.connectionCount(server.origin)).toBe(1);
+			// The server observes the session slightly after the client connects.
+			await waitFor(() => server.sessionCount() === 1);
+			await sleep(50);
+			expect(server.sessionCount()).toBe(1);
+
+			s1.close();
+			s2.close();
+			server.endAllStreams();
+			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"spills over to a new connection beyond the concurrency cap",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool({
+				maxConcurrentStreamsPerConnection: 2,
+			});
+
+			pool.attach(server.origin);
+			const streams = await Promise.all([
+				pool.request(server.origin, GET_HEADERS),
+				pool.request(server.origin, GET_HEADERS),
+				pool.request(server.origin, GET_HEADERS),
+			]);
+
+			expect(pool.connectionCount(server.origin)).toBe(2);
+			await waitFor(() => server.sessionCount() === 2);
+			await sleep(50);
+			expect(server.sessionCount()).toBe(2);
+
+			// Freed capacity is reused instead of dialing again.
+			for (const stream of streams) {
+				stream.close();
+			}
+			server.endAllStreams();
+			await waitFor(() => {
+				// All client streams closed; both connections have spare capacity.
+				return streams.every((s) => s.closed);
+			});
+			const reused = await pool.request(server.origin, GET_HEADERS);
+			await sleep(50);
+			expect(server.sessionCount()).toBe(2);
+
+			reused.close();
+			server.endAllStreams();
+			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"closes connections only when the last attachment detaches",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+
+			pool.attach(server.origin);
+			pool.attach(server.origin);
+			const stream = await pool.request(server.origin, GET_HEADERS);
+			stream.close();
+			server.endAllStreams();
+
+			await pool.detach(server.origin);
+			await sleep(50);
+			expect(server.openSessions().size).toBe(1);
+
+			await pool.detach(server.origin);
+			await waitFor(() => server.openSessions().size === 0);
+			expect(pool.connectionCount(server.origin)).toBe(0);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"replaces a connection that died on the next request",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+
+			pool.attach(server.origin);
+			const first = await pool.request(server.origin, GET_HEADERS);
+			first.on("error", () => {});
+			await waitFor(() => server.sessionCount() === 1);
+
+			for (const session of server.openSessions()) {
+				session.destroy();
+			}
+			await waitFor(() => pool.connectionCount(server.origin) === 0);
+
+			const second = await pool.request(server.origin, GET_HEADERS);
+			await waitFor(() => server.sessionCount() === 2);
+
+			second.close();
+			server.endAllStreams();
+			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+});
+
+describe("S2STransport connection sharing", () => {
+	it(
+		"shares one connection across transports and closes it on last close",
+		async () => {
+			// Speak just enough s2s: a terminal frame with status 200 ends a read cleanly.
+			const server = await startServer((stream) => {
+				stream.end(
+					Buffer.from(
+						frameMessage({
+							terminal: true,
+							statusCode: 200,
+							body: new Uint8Array(0),
+						}),
+					),
+				);
+			});
+
+			try {
+				const makeTransport = () =>
+					new S2STransport({
+						baseUrl: `${server.origin}/v1`,
+						accessToken: Redacted.make("test-token"),
+					});
+				const transport1 = makeTransport();
+				const transport2 = makeTransport();
+
+				const drain = async (transport: S2STransport) => {
+					const session = await transport.makeReadSession("test-stream");
+					for await (const _record of session) {
+						// terminal frame carries no records
+					}
+				};
+
+				await drain(transport1);
+				await drain(transport2);
+				expect(server.sessionCount()).toBe(1);
+
+				await transport1.close();
+				await sleep(50);
+				expect(server.openSessions().size).toBe(1);
+
+				// The surviving transport still works over the pooled connection.
+				await drain(transport2);
+				expect(server.sessionCount()).toBe(1);
+
+				await transport2.close();
+				await waitFor(() => server.openSessions().size === 0);
+			} finally {
+				await server.close().catch(() => {});
+			}
+		},
+		TEST_TIMEOUT_MS,
+	);
+});


### PR DESCRIPTION
Closes #29.

## Problem

Every `S2Stream` handle creates its own `S2STransport`, and each transport dialed its own HTTP/2 connection. N stream handles against the same basin endpoint meant N connections.

## Change

**`s2s/pool.ts` (new)**: `Http2ConnectionPool` with a process-wide singleton keyed by endpoint origin (safe to share across clients since auth is a per-request header):

- Connections are opened lazily on the first request; concurrent first-requests share a single in-flight connect, with capacity accounting so a burst larger than the cap opens a second connection instead of queueing everything on one.
- Up to 100 concurrent streams per connection (matches the `maxConcurrentStreams` S2 servers advertise); excess load spills over to additional connections, and freed capacity is reused before opening more.
- Connections are evicted from the pool on `goaway`/`error`/`close`, so the next request reconnects.
- Connect logic (10 MiB windows, connection timeout, Deno-safe `setLocalWindowSize`) moved here from the transport, plus one hardening fix: pooled sessions keep a permanent `error` listener. Previously a second post-connect session error had no listener and would have crashed the process.

**`s2s/index.ts`**: `S2STransport` no longer owns a connection. It attaches to the pool on first use and detaches on `close()`; the pool refcounts attachments per endpoint and gracefully closes connections only when the last transport detaches. Closing one stream handle can no longer tear down a connection another handle is using, and the process can still exit cleanly once all handles are closed. Sessions receive an `openH2Stream(headers)` callback instead of `getConnection()`.

Note: with the account endpoint + `s2-basin` header, all basins share one origin and therefore one pooled connection (until spillover), which matches "per basin endpoint" since the endpoint is genuinely shared there.

## Testing

New `h2-pool.test.ts` against a local h2c server: lazy connect, connect sharing, spillover past the cap, capacity reuse after streams close, refcounted teardown, dead-connection replacement, and an end-to-end `S2STransport` test speaking real s2s framing that proves two transports share one connection and it closes on the last `close()`.

`bun run check`, `bun run build`, and the full unit suite (426 tests) pass. E2E was not run locally (no token in the environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
