### PR TITLE
feat: configurable HTTP/2 flow-control windows for the s2s transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,36 @@ const stream = basin.stream(streamName, {
 > [!IMPORTANT]
 > HTTP/2 library use, required for `s2s`, is enabled by default on Node.js, Bun >= 1.3.11, and Deno >= 2.7.5. Older Bun and Deno versions default to HTTP/1.1 due to `node:http2` bugs in those runtimes ([#113](https://github.com/s2-streamstore/s2-sdk-typescript/issues/113), [#169](https://github.com/s2-streamstore/s2-sdk-typescript/issues/169)), but `s2s` can be forced using the mechanism described above.
 
+### HTTP/2 flow control
+
+The `s2s` transport pools HTTP/2 connections per endpoint and multiplexes up to
+100 sessions on each connection. Flow-control windows bound how much data the
+server can keep in flight before the client acknowledges it — per session, and
+summed across a connection. Both windows default to 10 MiB, which suits most
+workloads; they become worth raising when high-throughput reads traverse
+high-latency links (bandwidth-delay product exceeding the window), or when many
+concurrent read sessions share one connection:
+
+<!-- snippet:start h2-flow-control -->
+```ts
+// Larger flow-control windows let the server keep more read data in flight,
+// which helps saturate high-throughput reads over high-latency links.
+const s2 = new S2({
+	...S2Environment.parse(),
+	accessToken,
+	http2: {
+		// Per read session (HTTP/2 stream); S2 read batches are up to 1 MiB.
+		initialStreamWindowSize: 32 * 1024 * 1024,
+		// Per connection, shared by up to 100 sessions multiplexed on it.
+		connectionWindowSize: 64 * 1024 * 1024,
+	},
+});
+```
+<!-- snippet:end h2-flow-control -->
+
+Clients configured with different `http2` settings do not share pooled
+connections. These settings have no effect on the `fetch` transport.
+
 ## Patterns
 
 For higher-level, more opinionated building blocks (typed append/read sessions, framing, dedupe helpers), see the [patterns](packages/patterns/README.md) package.

--- a/examples/h2-flow-control.ts
+++ b/examples/h2-flow-control.ts
@@ -1,0 +1,45 @@
+import { S2, S2Environment, S2Error } from "@s2-dev/streamstore";
+
+const accessToken = process.env.S2_ACCESS_TOKEN;
+if (!accessToken) {
+	throw new Error("Set S2_ACCESS_TOKEN to tune HTTP/2 flow control.");
+}
+
+const basinName = process.env.S2_BASIN;
+if (!basinName) {
+	throw new Error("Set S2_BASIN so we know which basin to read from.");
+}
+
+const streamName = process.env.S2_STREAM ?? "docs/h2-flow-control";
+
+// snippet-region h2-flow-control start
+// Larger flow-control windows let the server keep more read data in flight,
+// which helps saturate high-throughput reads over high-latency links.
+const s2 = new S2({
+	...S2Environment.parse(),
+	accessToken,
+	http2: {
+		// Per read session (HTTP/2 stream); S2 read batches are up to 1 MiB.
+		initialStreamWindowSize: 32 * 1024 * 1024,
+		// Per connection, shared by up to 100 sessions multiplexed on it.
+		connectionWindowSize: 64 * 1024 * 1024,
+	},
+});
+// snippet-region h2-flow-control end
+
+const basin = s2.basin(basinName);
+await basin.streams.create({ stream: streamName }).catch((error: unknown) => {
+	if (!(error instanceof S2Error && error.status === 409)) {
+		throw error;
+	}
+});
+
+const stream = basin.stream(streamName);
+const readSession = await stream.readSession({
+	start: { from: { tailOffset: 10 }, clamp: true },
+	stop: { waitSecs: 10 },
+});
+for await (const record of readSession) {
+	console.log(record.seqNum, record.body);
+}
+await stream.close();

--- a/packages/streamstore/src/basin.ts
+++ b/packages/streamstore/src/basin.ts
@@ -8,7 +8,11 @@ import {
 	canSetUserAgentHeader,
 	DEFAULT_USER_AGENT,
 } from "./lib/stream/runtime.js";
-import type { SessionTransports, TransportConfig } from "./lib/stream/types.js";
+import type {
+	Http2Settings,
+	SessionTransports,
+	TransportConfig,
+} from "./lib/stream/types.js";
 import { S2Stream } from "./stream.js";
 import { S2Streams } from "./streams.js";
 
@@ -34,6 +38,7 @@ export class S2Basin {
 			includeBasinHeader: boolean;
 			retryConfig?: RetryConfig;
 			compression?: S2Compression;
+			http2?: Http2Settings;
 		},
 	) {
 		this.name = name;
@@ -46,6 +51,7 @@ export class S2Basin {
 			requestTimeoutMillis: options.retryConfig?.requestTimeoutMillis,
 			retry: options.retryConfig,
 			compression: options.compression,
+			http2: options.http2,
 		};
 		const headers: Record<string, string> = {};
 		if (options.includeBasinHeader) {

--- a/packages/streamstore/src/common.ts
+++ b/packages/streamstore/src/common.ts
@@ -1,5 +1,6 @@
 import { S2Endpoints, type S2EndpointsInit } from "./endpoints.js";
 import type { CompressionType } from "./lib/stream/transport/s2s/framing.js";
+import type { Http2Settings } from "./lib/stream/types.js";
 
 /**
  * Compression algorithm for s2s session frame bodies.
@@ -152,6 +153,14 @@ export type S2ClientOptions = {
 	 * Defaults to `"none"`.
 	 */
 	compression?: S2Compression;
+	/**
+	 * HTTP/2 flow-control tuning for sessions using the s2s transport.
+	 *
+	 * The defaults (10 MiB windows) suit most workloads; raise the windows to
+	 * keep high-throughput reads saturated over high-latency links. Ignored
+	 * by the fetch transport.
+	 */
+	http2?: Http2Settings;
 };
 
 /**

--- a/packages/streamstore/src/index.ts
+++ b/packages/streamstore/src/index.ts
@@ -185,6 +185,7 @@ export type {
 	AcksStream,
 	AppendHeaders,
 	AppendSession,
+	Http2Settings,
 	ReadHeaders,
 	ReadSession,
 	SessionTransports,

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -152,11 +152,15 @@ export class S2STransport implements SessionTransport {
 			});
 		}
 		if (!this.attached) {
-			sharedConnectionPool.attach(this.endpointOrigin);
+			sharedConnectionPool.attach(
+				this.endpointOrigin,
+				this.transportConfig.http2,
+			);
 			this.attached = true;
 		}
 		return sharedConnectionPool.request(this.endpointOrigin, headers, {
 			connectionTimeoutMillis: this.transportConfig.connectionTimeoutMillis,
+			http2: this.transportConfig.http2,
 		});
 	}
 
@@ -169,7 +173,10 @@ export class S2STransport implements SessionTransport {
 		this.closingPromise = (async () => {
 			if (this.attached) {
 				this.attached = false;
-				await sharedConnectionPool.detach(this.endpointOrigin);
+				await sharedConnectionPool.detach(
+					this.endpointOrigin,
+					this.transportConfig.http2,
+				);
 			}
 		})();
 

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -1,21 +1,60 @@
 /**
  * Shared HTTP/2 connection pool for the s2s transport.
  *
- * One connection per endpoint, opened lazily on the first request. Each
- * connection carries up to `maxConcurrentStreamsPerConnection` concurrent
- * streams; beyond that, additional connections are opened.
+ * Connections are pooled per endpoint and HTTP/2 settings, opened lazily on
+ * the first request. Each connection carries up to
+ * `maxConcurrentStreamsPerConnection` concurrent streams; beyond that,
+ * additional connections are opened.
  */
 
 import type { OutgoingHttpHeaders } from "node:http";
 import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
 import createDebug from "debug";
 import { S2Error } from "../../../../error.js";
+import type { Http2Settings } from "../../types.js";
 
 const debug = createDebug("s2:s2s:pool");
 
+// S2 advertises SETTINGS_MAX_CONCURRENT_STREAMS = 100; not a user knob.
 const MAX_CONCURRENT_STREAMS_PER_CONNECTION = 100;
 const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
-const INITIAL_WINDOW_SIZE = 10 * 1024 * 1024; // 10 MiB
+const DEFAULT_WINDOW_SIZE = 10 * 1024 * 1024; // 10 MiB
+const MIN_WINDOW_SIZE = 65_535; // HTTP/2 default window
+const MAX_WINDOW_SIZE = 2 ** 31 - 1; // RFC 9113 maximum
+
+interface ResolvedHttp2Settings {
+	initialStreamWindowSize: number;
+	connectionWindowSize: number;
+}
+
+function validateWindowSize(name: string, value: number): void {
+	if (
+		!Number.isInteger(value) ||
+		value < MIN_WINDOW_SIZE ||
+		value > MAX_WINDOW_SIZE
+	) {
+		throw new S2Error({
+			message: `http2.${name} must be an integer between ${MIN_WINDOW_SIZE} and ${MAX_WINDOW_SIZE}, got ${value}`,
+			status: 400,
+			origin: "sdk",
+		});
+	}
+}
+
+function resolveHttp2Settings(settings?: Http2Settings): ResolvedHttp2Settings {
+	const initialStreamWindowSize =
+		settings?.initialStreamWindowSize ?? DEFAULT_WINDOW_SIZE;
+	const connectionWindowSize =
+		settings?.connectionWindowSize ?? DEFAULT_WINDOW_SIZE;
+	validateWindowSize("initialStreamWindowSize", initialStreamWindowSize);
+	validateWindowSize("connectionWindowSize", connectionWindowSize);
+	return { initialStreamWindowSize, connectionWindowSize };
+}
+
+// Clients with equal resolved settings share connections to an origin.
+function endpointKey(origin: string, settings: ResolvedHttp2Settings): string {
+	return `${origin}|isw=${settings.initialStreamWindowSize}|cw=${settings.connectionWindowSize}`;
+}
 
 type Http2Module = typeof import("node:http2");
 
@@ -47,10 +86,13 @@ interface Endpoint {
 	refCount: number;
 	connections: PooledConnection[];
 	pending: PendingConnection[];
+	origin: string;
+	settings: ResolvedHttp2Settings;
 }
 
 interface RequestStreamOptions {
 	connectionTimeoutMillis?: number;
+	http2?: Http2Settings;
 }
 
 export class Http2ConnectionPool {
@@ -64,15 +106,24 @@ export class Http2ConnectionPool {
 	}
 
 	/**
-	 * Register as a user of an endpoint. Must be paired with a `detach` call;
-	 * connections are shared by all attached users and closed on last detach.
+	 * Register as a user of an endpoint. Must be paired with a `detach` call
+	 * with the same settings; connections are shared by all users attached
+	 * with equal settings and closed on last detach.
 	 */
-	attach(origin: string): void {
-		const endpoint = this.endpoints.get(origin);
+	attach(origin: string, http2?: Http2Settings): void {
+		const settings = resolveHttp2Settings(http2);
+		const key = endpointKey(origin, settings);
+		const endpoint = this.endpoints.get(key);
 		if (endpoint) {
 			endpoint.refCount += 1;
 		} else {
-			this.endpoints.set(origin, { refCount: 1, connections: [], pending: [] });
+			this.endpoints.set(key, {
+				refCount: 1,
+				connections: [],
+				pending: [],
+				origin,
+				settings,
+			});
 		}
 	}
 
@@ -80,8 +131,9 @@ export class Http2ConnectionPool {
 	 * The inverse of `attach`. When the last user detaches, all connections
 	 * to the endpoint are closed gracefully.
 	 */
-	async detach(origin: string): Promise<void> {
-		const endpoint = this.endpoints.get(origin);
+	async detach(origin: string, http2?: Http2Settings): Promise<void> {
+		const key = endpointKey(origin, resolveHttp2Settings(http2));
+		const endpoint = this.endpoints.get(key);
 		if (!endpoint) {
 			return;
 		}
@@ -89,7 +141,7 @@ export class Http2ConnectionPool {
 		if (endpoint.refCount > 0) {
 			return;
 		}
-		this.endpoints.delete(origin);
+		this.endpoints.delete(key);
 
 		// Wait for in-progress connects; successful ones land in `connections`.
 		await Promise.all(
@@ -122,8 +174,9 @@ export class Http2ConnectionPool {
 		headers: OutgoingHttpHeaders,
 		options?: RequestStreamOptions,
 	): Promise<ClientHttp2Stream> {
+		const key = endpointKey(origin, resolveHttp2Settings(options?.http2));
 		for (let attempt = 0; attempt < 3; attempt++) {
-			const endpoint = this.endpoints.get(origin);
+			const endpoint = this.endpoints.get(key);
 			if (!endpoint) {
 				throw new S2Error({
 					message: `HTTP/2 connection pool is not attached to ${origin}`,
@@ -144,7 +197,7 @@ export class Http2ConnectionPool {
 				(p) => p.reservations < this.maxStreamsPerConnection,
 			);
 			if (!pending) {
-				pending = this.startConnect(origin, endpoint, options);
+				pending = this.startConnect(key, endpoint, options);
 			}
 			pending.reservations += 1;
 			const connection = await pending.promise;
@@ -162,8 +215,9 @@ export class Http2ConnectionPool {
 	}
 
 	/** Number of live pooled connections to an endpoint. */
-	connectionCount(origin: string): number {
-		return this.endpoints.get(origin)?.connections.length ?? 0;
+	connectionCount(origin: string, http2?: Http2Settings): number {
+		const key = endpointKey(origin, resolveHttp2Settings(http2));
+		return this.endpoints.get(key)?.connections.length ?? 0;
 	}
 
 	private openStream(
@@ -190,11 +244,11 @@ export class Http2ConnectionPool {
 	}
 
 	private startConnect(
-		origin: string,
+		key: string,
 		endpoint: Endpoint,
 		options?: RequestStreamOptions,
 	): PendingConnection {
-		const connectPromise = this.connect(origin, options);
+		const connectPromise = this.connect(key, endpoint, options);
 		const pending: PendingConnection = {
 			reservations: 0,
 			promise: connectPromise,
@@ -218,14 +272,25 @@ export class Http2ConnectionPool {
 	}
 
 	private async connect(
-		origin: string,
+		key: string,
+		endpoint: Endpoint,
 		options?: RequestStreamOptions,
 	): Promise<PooledConnection> {
+		const { origin, settings } = endpoint;
 		debug("connecting to %s", origin);
 		const http2 = await loadHttp2();
 		const session = http2.connect(origin, {
+			// Headroom above the flow-control windows so Node's session memory
+			// cap (default 10 MB) does not refuse streams when windows are raised.
+			maxSessionMemory: Math.max(
+				10,
+				Math.ceil(
+					(settings.connectionWindowSize + settings.initialStreamWindowSize) /
+						2 ** 20,
+				) + 8,
+			),
 			settings: {
-				initialWindowSize: INITIAL_WINDOW_SIZE,
+				initialWindowSize: settings.initialStreamWindowSize,
 			},
 		});
 
@@ -246,7 +311,7 @@ export class Http2ConnectionPool {
 			session.once("connect", () => {
 				if (session.destroyed) return;
 				try {
-					session.setLocalWindowSize(INITIAL_WINDOW_SIZE);
+					session.setLocalWindowSize(settings.connectionWindowSize);
 				} catch {
 					// Not available in every runtime; performance-only.
 				}
@@ -259,9 +324,9 @@ export class Http2ConnectionPool {
 
 		// A connection that errors or shuts down should get no new streams.
 		// Its open streams observe the failure through their own events.
-		session.on("goaway", () => this.evict(origin, connection));
-		session.on("close", () => this.evict(origin, connection));
-		session.on("error", () => this.evict(origin, connection));
+		session.on("goaway", () => this.evict(key, connection));
+		session.on("close", () => this.evict(key, connection));
+		session.on("error", () => this.evict(key, connection));
 
 		const connectionTimeout =
 			options?.connectionTimeoutMillis ?? DEFAULT_CONNECTION_TIMEOUT_MS;
@@ -292,9 +357,9 @@ export class Http2ConnectionPool {
 		}
 	}
 
-	private evict(origin: string, connection: PooledConnection): void {
+	private evict(key: string, connection: PooledConnection): void {
 		connection.dead = true;
-		const endpoint = this.endpoints.get(origin);
+		const endpoint = this.endpoints.get(key);
 		if (endpoint) {
 			removeFrom(endpoint.connections, connection);
 		}

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -20,7 +20,7 @@ const MAX_CONCURRENT_STREAMS_PER_CONNECTION = 100;
 const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
 const DEFAULT_WINDOW_SIZE = 10 * 1024 * 1024; // 10 MiB
 const MIN_WINDOW_SIZE = 65_535; // HTTP/2 default window
-const MAX_WINDOW_SIZE = 2 ** 31 - 1; // RFC 9113 maximum
+const MAX_WINDOW_SIZE = 2 ** 31 - 1; // RFC 9113 (https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2-2.8.3)
 
 interface ResolvedHttp2Settings {
 	initialStreamWindowSize: number;
@@ -283,11 +283,11 @@ export class Http2ConnectionPool {
 			// Headroom above the flow-control windows so Node's session memory
 			// cap (default 10 MB) does not refuse streams when windows are raised.
 			maxSessionMemory: Math.max(
-				10,
+				10, // default maxSessionMemory
 				Math.ceil(
 					(settings.connectionWindowSize + settings.initialStreamWindowSize) /
 						2 ** 20,
-				) + 8,
+				) + 8, // 8 is a fixed overhead
 			),
 			settings: {
 				initialWindowSize: settings.initialStreamWindowSize,

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -282,6 +282,8 @@ export class Http2ConnectionPool {
 		const session = http2.connect(origin, {
 			// Headroom above the flow-control windows so Node's session memory
 			// cap (default 10 MB) does not refuse streams when windows are raised.
+			// This is just a heuristic to avoid memory issues in case.
+			// Deno and Bun dont support this setting.
 			maxSessionMemory: Math.max(
 				10, // default maxSessionMemory
 				Math.ceil(

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -135,6 +135,8 @@ export class Http2ConnectionPool {
 		const key = endpointKey(origin, resolveHttp2Settings(http2));
 		const endpoint = this.endpoints.get(key);
 		if (!endpoint) {
+			// Likely an attach/detach settings mismatch, which would leak the entry.
+			debug("detach for unknown endpoint %s", key);
 			return;
 		}
 		endpoint.refCount -= 1;

--- a/packages/streamstore/src/lib/stream/types.ts
+++ b/packages/streamstore/src/lib/stream/types.ts
@@ -233,6 +233,38 @@ export interface SessionTransport {
 
 export type SessionTransports = "fetch" | "s2s";
 
+/**
+ * HTTP/2 flow-control settings for the s2s transport.
+ *
+ * Only applies where sessions run over `s2s` (HTTP/2); the fetch transport
+ * ignores these. Connections are pooled per endpoint, and clients configured
+ * with different settings do not share connections.
+ */
+export interface Http2Settings {
+	/**
+	 * Flow-control receive window for each HTTP/2 stream, in bytes.
+	 *
+	 * Bounds how much data the server can have in flight on a single read
+	 * session before the client acknowledges it. Raise this to keep
+	 * high-throughput reads saturated over high-latency links; S2 read
+	 * batches can be up to 1 MiB each.
+	 *
+	 * Must be an integer between 65,535 and 2^31 - 1.
+	 * @default 10_485_760 (10 MiB)
+	 */
+	initialStreamWindowSize?: number;
+	/**
+	 * Flow-control receive window for each HTTP/2 connection, in bytes.
+	 *
+	 * Bounds in-flight data summed across all sessions multiplexed on one
+	 * connection (up to 100 streams per connection).
+	 *
+	 * Must be an integer between 65,535 and 2^31 - 1.
+	 * @default 10_485_760 (10 MiB)
+	 */
+	connectionWindowSize?: number;
+}
+
 export interface TransportConfig {
 	baseUrl: string;
 	accessToken: Redacted.Redacted;
@@ -262,4 +294,8 @@ export interface TransportConfig {
 	 * `Accept-Encoding`. Defaults to `"none"`.
 	 */
 	compression?: CompressionType;
+	/**
+	 * HTTP/2 flow-control settings for the s2s transport.
+	 */
+	http2?: Http2Settings;
 }

--- a/packages/streamstore/src/s2.ts
+++ b/packages/streamstore/src/s2.ts
@@ -11,6 +11,7 @@ import {
 	canSetUserAgentHeader,
 	DEFAULT_USER_AGENT,
 } from "./lib/stream/runtime.js";
+import type { Http2Settings } from "./lib/stream/types.js";
 import { S2Locations } from "./locations.js";
 import { S2Metrics } from "./metrics.js";
 
@@ -31,6 +32,7 @@ export class S2 {
 	private readonly endpoints: S2Endpoints;
 	private readonly retryConfig: RetryConfig;
 	private readonly compression?: S2Compression;
+	private readonly http2?: Http2Settings;
 
 	/**
 	 * Account-scoped basin management operations.
@@ -67,6 +69,8 @@ export class S2 {
 				? options.endpoints
 				: new S2Endpoints(options.endpoints);
 		this.compression = options.compression;
+		// Copy so later mutation of the caller's object cannot skew pool keying.
+		this.http2 = options.http2 ? { ...options.http2 } : undefined;
 		const headers: Record<string, string> = {};
 		if (canSetUserAgentHeader()) {
 			headers["user-agent"] = DEFAULT_USER_AGENT;
@@ -110,6 +114,7 @@ export class S2 {
 			includeBasinHeader: this.endpoints.includeBasinHeader,
 			retryConfig: this.retryConfig,
 			compression: this.compression,
+			http2: this.http2,
 		});
 	}
 }

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -249,6 +249,121 @@ describe("Http2ConnectionPool", () => {
 	);
 
 	it(
+		"applies configured flow-control windows to new connections",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+			const http2 = {
+				initialStreamWindowSize: 2 * 1024 * 1024,
+				connectionWindowSize: 4 * 1024 * 1024,
+			};
+
+			pool.attach(server.origin, http2);
+			const stream = await pool.request(server.origin, GET_HEADERS, { http2 });
+			await waitFor(() => server.sessionCount() === 1);
+			const [session] = [...server.openSessions()];
+			if (!session) throw new Error("no server session");
+
+			// The client's SETTINGS frame carries the stream window; its
+			// WINDOW_UPDATE raises the connection window the server may use.
+			await waitFor(
+				() =>
+					session.remoteSettings.initialWindowSize ===
+					http2.initialStreamWindowSize,
+			);
+			await waitFor(
+				() => session.state.remoteWindowSize === http2.connectionWindowSize,
+			);
+
+			stream.close();
+			server.endAllStreams();
+			await pool.detach(server.origin, http2);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"does not share connections across different flow-control settings",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+			const a = { initialStreamWindowSize: 1024 * 1024 };
+			const b = { initialStreamWindowSize: 2 * 1024 * 1024 };
+
+			pool.attach(server.origin, a);
+			pool.attach(server.origin, b);
+			const s1 = await pool.request(server.origin, GET_HEADERS, { http2: a });
+			const s2 = await pool.request(server.origin, GET_HEADERS, { http2: b });
+
+			expect(pool.connectionCount(server.origin, a)).toBe(1);
+			expect(pool.connectionCount(server.origin, b)).toBe(1);
+			await waitFor(() => server.sessionCount() === 2);
+
+			s1.close();
+			s2.close();
+			server.endAllStreams();
+
+			// Detaching one settings bucket leaves the other's connection open.
+			await pool.detach(server.origin, a);
+			await sleep(50);
+			expect(server.openSessions().size).toBe(1);
+
+			await pool.detach(server.origin, b);
+			await waitFor(() => server.openSessions().size === 0);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"shares a connection across users attached with equal settings",
+		async () => {
+			const server = await newServer();
+			const pool = new Http2ConnectionPool();
+			const settings = () => ({ initialStreamWindowSize: 1024 * 1024 });
+
+			pool.attach(server.origin, settings());
+			pool.attach(server.origin, settings());
+			const s1 = await pool.request(server.origin, GET_HEADERS, {
+				http2: settings(),
+			});
+			const s2 = await pool.request(server.origin, GET_HEADERS, {
+				http2: settings(),
+			});
+
+			expect(pool.connectionCount(server.origin, settings())).toBe(1);
+			await waitFor(() => server.sessionCount() === 1);
+
+			s1.close();
+			s2.close();
+			server.endAllStreams();
+			await pool.detach(server.origin, settings());
+			await pool.detach(server.origin, settings());
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"rejects invalid flow-control window sizes",
+		async () => {
+			const pool = new Http2ConnectionPool();
+			const origin = "http://127.0.0.1:1";
+
+			expect(() => pool.attach(origin, { initialStreamWindowSize: 0 })).toThrow(
+				/initialStreamWindowSize/,
+			);
+			expect(() =>
+				pool.attach(origin, { connectionWindowSize: 2 ** 31 }),
+			).toThrow(/connectionWindowSize/);
+			expect(() =>
+				pool.attach(origin, {
+					initialStreamWindowSize: 1.5 * 1024 * 1024 + 0.5,
+				}),
+			).toThrow(/initialStreamWindowSize/);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"replaces a connection that died on the next request",
 		async () => {
 			const server = await newServer();
@@ -270,6 +385,60 @@ describe("Http2ConnectionPool", () => {
 			second.close();
 			server.endAllStreams();
 			await pool.detach(server.origin);
+		},
+		TEST_TIMEOUT_MS,
+	);
+});
+
+describe("S2STransport http2 settings", () => {
+	it(
+		"plumbs configured windows through to the pooled connection",
+		async () => {
+			const server = await startServer((stream) => {
+				stream.end(
+					Buffer.from(
+						frameMessage({
+							terminal: true,
+							statusCode: 200,
+							body: new Uint8Array(0),
+						}),
+					),
+				);
+			});
+
+			try {
+				const transport = new S2STransport({
+					baseUrl: `${server.origin}/v1`,
+					accessToken: Redacted.make("test-token"),
+					http2: {
+						initialStreamWindowSize: 3 * 1024 * 1024,
+						connectionWindowSize: 5 * 1024 * 1024,
+					},
+				});
+
+				const session = await transport.makeReadSession("test-stream");
+				for await (const _record of session) {
+					// terminal frame carries no records
+				}
+
+				const [serverSession] = [...server.openSessions()];
+				if (!serverSession) throw new Error("no server session");
+				await waitFor(
+					() =>
+						serverSession.remoteSettings.initialWindowSize === 3 * 1024 * 1024,
+				);
+				// The terminal frame consumed a few bytes of the window already.
+				await waitFor(
+					() =>
+						(serverSession.state.remoteWindowSize ?? 0) >=
+						5 * 1024 * 1024 - 1024,
+				);
+
+				await transport.close();
+				await waitFor(() => server.openSessions().size === 0);
+			} finally {
+				await server.close().catch(() => {});
+			}
 		},
 		TEST_TIMEOUT_MS,
 	);

--- a/scripts/sync-snippets.mjs
+++ b/scripts/sync-snippets.mjs
@@ -49,6 +49,12 @@ const SNIPPETS = [
 		region: "force-transport",
 		lang: "ts",
 	},
+	{
+		name: "h2-flow-control",
+		file: "examples/h2-flow-control.ts",
+		region: "h2-flow-control",
+		lang: "ts",
+	},
 ];
 
 const loadedSnippets = new Map(


### PR DESCRIPTION
Closes #58.

Adds an `http2` option to `S2ClientOptions` for tuning HTTP/2 flow control on the s2s transport:

- `initialStreamWindowSize` — per-stream receive window; bounds how much data the server can keep in flight on a single read session. Default 10 MiB (previous hardcoded value).
- `connectionWindowSize` — connection-level receive window; bounds in-flight data summed across all sessions multiplexed on one connection. Default 10 MiB.

Both are validated as integers in `[65_535, 2^31 - 1]`. The per-connection stream cap stays hardcoded at 100 to match what S2 advertises via `SETTINGS_MAX_CONCURRENT_STREAMS`.

### Pool changes

- Connections are now pooled per **origin + resolved settings** instead of per origin, so clients configured with different windows never share a connection, while equal-settings clients (including unset vs. explicit defaults) still share as before. `attach`/`detach` refcounting operates on the composite key.
- `http2.connect` gets `maxSessionMemory` headroom scaled from the configured windows, so raising windows past Node's 10 MB default session-memory cap doesn't cause refused streams.
- The `S2` constructor copies the caller's `http2` object so later mutation can't skew pool keying.

### Docs & tests

- New "HTTP/2 flow control" README section (when raising windows helps) backed by a runnable, snippet-synced `examples/h2-flow-control.ts`.
- New pool tests: configured windows observed server-side (SETTINGS + WINDOW_UPDATE), no sharing across different settings with per-bucket detach, sharing across equal settings, validation rejections, and an end-to-end `S2STransport` plumb-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)