### PR TITLE
fix: resolve resumable-stream generic resumer issues (#309, #312)

### DIFF
--- a/packages/resumable-stream/src/index.ts
+++ b/packages/resumable-stream/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+	AppendAck,
 	ReadBatch,
 	S2Endpoints,
 	S2EndpointsInit,
@@ -17,6 +18,7 @@ import {
 	isTrimRecord,
 	persistToS2,
 } from "./protocol.js";
+import { isMissingStreamError } from "./shared.js";
 
 interface S2Config {
 	/**
@@ -152,13 +154,14 @@ export async function createResumableStream(
 			debugLog("Got RangeNotSatisfiableError:", error);
 		} else {
 			debugLog("Error checking stream status:", error);
-			return null;
+			throw error;
 		}
 	}
 
 	// in case of multiple writers, only one with the given fencing token will succeed
+	let fenceAck: AppendAck;
 	try {
-		await appendFenceCommand(
+		fenceAck = await appendFenceCommand(
 			s2.basin(basin).stream(streamId),
 			"",
 			sessionFencingToken,
@@ -173,7 +176,7 @@ export async function createResumableStream(
 			return await resumeStream(streamId);
 		}
 		debugLog("Error initializing stream:", error);
-		return null;
+		throw error;
 	}
 
 	// Created only after validation so the early returns above don't leak
@@ -196,8 +199,9 @@ export async function createResumableStream(
 						`${sourceError !== undefined ? "error" : "end"}-${generateFencingToken()}`,
 					),
 				],
+				matchSeqNumStart: fenceAck.end.seqNum,
 				onSeqNumMismatch: () => {
-					debugLog("seqNum mismatch, skipping record");
+					debugLog("seqNum mismatch, another writer advanced the stream");
 				},
 			});
 		} catch (error) {
@@ -294,9 +298,13 @@ async function resumeStream(
 			},
 		});
 	} catch (error: unknown) {
-		debugLog("Error reading stream:", error);
 		await handle.close?.();
-		return null;
+		if (isMissingStreamError(error)) {
+			debugLog("No stream to resume:", streamId, error);
+			return null;
+		}
+		debugLog("Error reading stream:", error);
+		throw error;
 	}
 }
 

--- a/packages/resumable-stream/src/tests/reproductions/issue-194.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-194.test.ts
@@ -12,7 +12,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
  * After the fix, resumeStream() should return null when readSession() throws.
  */
 
-// Mock S2 so readSession throws immediately (simulating 404/403)
+// Mock S2 so readSession throws immediately (simulating a missing stream)
 vi.mock("@s2-dev/streamstore", async () => {
 	const actual = await vi.importActual<typeof import("@s2-dev/streamstore")>(
 		"@s2-dev/streamstore",
@@ -21,7 +21,14 @@ vi.mock("@s2-dev/streamstore", async () => {
 		basin() {
 			return {
 				stream: () => ({
-					readSession: () => Promise.reject(new Error("Not Found (404)")),
+					readSession: () =>
+						Promise.reject(
+							new actual.S2Error({
+								message: "stream not found",
+								status: 404,
+								code: "stream_not_found",
+							}),
+						),
 				}),
 			};
 		}

--- a/packages/resumable-stream/src/tests/reproductions/issue-237.test.ts
+++ b/packages/resumable-stream/src/tests/reproductions/issue-237.test.ts
@@ -1,6 +1,7 @@
 import {
 	FencingTokenMismatchError,
 	RangeNotSatisfiableError,
+	S2Error,
 } from "@s2-dev/streamstore";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -96,9 +97,9 @@ describe("Issue #237: no stream is created when validation fails", () => {
 		const makeStream = vi.fn(() => new ReadableStream<string>());
 		const ctx = await makeCtx();
 
-		const result = await ctx.resumableStream("broken-stream", makeStream);
-
-		expect(result).toBeNull();
+		await expect(
+			ctx.resumableStream("broken-stream", makeStream),
+		).rejects.toThrow("boom");
 		expect(makeStream).not.toHaveBeenCalled();
 	}, 10_000);
 
@@ -112,8 +113,15 @@ describe("Issue #237: no stream is created when validation fails", () => {
 						expectedFencingToken: "other-writer",
 					}),
 				),
-			// resumeStream path; reject so it resolves to null.
-			readSession: () => Promise.reject(new Error("Not Found (404)")),
+			// resumeStream path; a missing stream resolves to null.
+			readSession: () =>
+				Promise.reject(
+					new S2Error({
+						message: "stream not found",
+						status: 404,
+						code: "stream_not_found",
+					}),
+				),
 		};
 		const makeStream = vi.fn(() => new ReadableStream<string>());
 		const ctx = await makeCtx();
@@ -132,9 +140,9 @@ describe("Issue #237: no stream is created when validation fails", () => {
 		const makeStream = vi.fn(() => new ReadableStream<string>());
 		const ctx = await makeCtx();
 
-		const result = await ctx.resumableStream("unappendable-stream", makeStream);
-
-		expect(result).toBeNull();
+		await expect(
+			ctx.resumableStream("unappendable-stream", makeStream),
+		).rejects.toThrow("append failed");
 		expect(makeStream).not.toHaveBeenCalled();
 	}, 10_000);
 


### PR DESCRIPTION
## Summary

Fixes the two open resumable-stream issues, both in the generic resumer (`packages/resumable-stream/src/index.ts`).

### #309 — silent data loss when the stream already has records
`createResumableStream` discarded the `AppendAck` returned by its fence append, so `persistToS2` never received `matchSeqNumStart` and fell back to `matchSeqNum: 1`. On a stream that already had records (e.g. created directly via the SDK with `createStreamOnAppend`), every append then failed with a `SeqNumMismatchError` that the `onSeqNumMismatch` callback swallowed — the source was fully consumed but **nothing was persisted**.

Now the fence ack's `end.seqNum` is threaded through as `matchSeqNumStart`, so persistence matches from the correct tail position.

### #312 — infra errors masked as "stream ended"
The pre-flight status `read()` and the fence `append()` catch blocks returned `null` for *any* unexpected error (502/403/500/network), which is indistinguishable from "stream already ended" — the README pattern maps `null` to a 422. Callers could not retry or surface the real failure.

Now unexpected errors propagate. `null` is reserved for a genuinely finished stream, and (on resume) a missing one — detected via the existing `isMissingStreamError` helper rather than swallowing everything.

## Changes
- `index.ts`: capture `fenceAck`, pass `matchSeqNumStart: fenceAck.end.seqNum` to `persistToS2`; `throw` instead of `return null` on unexpected errors in the status check, fence append, and `resumeStream`'s read-session catch (gated on `isMissingStreamError` for the null case); corrected the misleading `onSeqNumMismatch` debug message.
- Updated existing reproduction tests (`issue-194`, `issue-237`) that pinned the old null-on-error behavior to assert the new throw/`S2Error(404)` semantics.

## Testing
`bun run test` (66 pass), `bun run check`, and `biome check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)