### PR TITLE
fix: mark AccessTokenInfo.autoPrefixStreams as required (#311)

### DIFF
--- a/packages/streamstore/src/types.ts
+++ b/packages/streamstore/src/types.ts
@@ -847,7 +847,7 @@ export interface AccessTokenInfo {
 	/** Access token scope. */
 	scope: AccessTokenScope;
 	/** Whether streams are auto-prefixed. */
-	autoPrefixStreams?: boolean;
+	autoPrefixStreams: boolean;
 	/** Expiration time. */
 	expiresAt?: Date | null;
 }


### PR DESCRIPTION
## Summary

Fixes #311. The public `AccessTokenInfo` type marked `autoPrefixStreams` as optional, contradicting the API contract.

- The generated API type defines `auto_prefix_streams: boolean` as **required** (`generated/types.gen.ts:13`).
- The response transform (`transformTokenInfo` in `accessTokens.ts`) spreads the whole camel-cased response through, so the field is always populated at runtime.
- An existing unit test already assumes presence: `expect(info.autoPrefixStreams).toBe(true)` (`case-transform.test.ts`).

Marking it optional forced downstream TypeScript users to treat an always-present value as possibly `undefined`, inviting unnecessary defensive code or subtle logic bugs.

## Change
One line in `packages/streamstore/src/types.ts`: `autoPrefixStreams?: boolean` → `autoPrefixStreams: boolean` on the **response** type `AccessTokenInfo`. The optional field on `IssueAccessTokenInput` (a request, where omission is valid) is intentionally left unchanged.

## Testing
`bun run check` (typecheck) clean; `case-transform.test.ts` (17 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)