### PR TITLE
fix: await in-flight stream init in S2SAppendSession.close (#306)

### DIFF
--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -1000,6 +1000,16 @@ class S2SAppendSession implements TransportAppendSession {
 		try {
 			this.closed = true;
 
+			// Wait for any in-flight lazy initialization to finish. Otherwise a
+			// concurrent initializeStream() can open and assign the HTTP/2 stream
+			// after close() has already returned, orphaning it and permanently
+			// holding a pool slot (activeStreams only decrements on stream close).
+			// initPromise is only set by submit(), so if it's unset no stream was
+			// ever opened and there is nothing to await.
+			if (this.initPromise) {
+				await this.initPromise.catch(() => {});
+			}
+
 			// Wait for all pending acks to complete
 			while (this.pendingAcks.length > 0) {
 				await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
## Summary

Fixes #306. `S2SAppendSession.close()` returned without awaiting the in-flight lazy initialization, leaking an HTTP/2 stream (and its pool slot) when `close()` raced `initializeStream()`.

## The bug

`submit()` lazily kicks off `this.initPromise = this.initializeStream()`, which `await`s `openH2Stream()` (a full pool request + possibly a TLS/H2 handshake) before assigning `this.http2Stream`. If `close()` runs during that window:

- `pendingAcks` is empty (the racing `submit()` is still parked on `await this.initPromise`) and `http2Stream` is still `undefined`, so `close()` skips its stream-close block and returns immediately.
- `initializeStream()` then resolves and assigns `this.http2Stream = stream` on the now-abandoned session. Nothing ever calls `.end()`/`.close()` on it.
- The pool only decrements `activeStreams` inside the stream's `once("close")` handler (`s2s/pool.ts:242`), so the orphaned stream holds its slot for the life of the connection. Accumulated leaks throttle and eventually starve the pool (`maxStreamsPerConnection`).

`RetryAppendSession.recover()` (`retry.ts:1428`) triggers this in the wild: it `await`s `session.close()` then sets `this.session = undefined`, trusting `close()` to have fully torn the session down.

It's an interleaving bug, not a steady-state leak — pipelined submits that let init finish before closing are unaffected. It bites on early close, cancellation/abort teardown, and recovery churn.

## The fix

`close()` now awaits `this.initPromise` (guarded with `.catch(() => {})`, since init can reject) before checking `http2Stream`. Once it resolves, `http2Stream` is assigned and the existing `.end()` closes it cleanly. `initPromise` is only ever set by `submit()`, so a session that was never submitted to has nothing to await and opened no stream — the "close before first submit" case is covered for free.

## Testing

`bun run check` (typecheck) clean. Ran the transport/pool/append/retry unit suites — 52 tests pass (`s2s-transport`, `h2-pool`, `appendSession`, `retryAppendSession`, `retry`).

Note: the reproduction test the issue references (`test-close-during-init.test.ts`) does not exist in the repo; the fix is verified against the source paths and existing suites rather than that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)