### PR TITLE
fix: remove abort listener on S2SAppendSession close (#307)

### DIFF
--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -708,6 +708,7 @@ class S2SAppendSession implements TransportAppendSession {
 	}>();
 	private initPromise?: Promise<void>;
 	private _effectSignalled = false;
+	private abortHandler?: () => void;
 
 	static async create(
 		baseUrl: string,
@@ -774,11 +775,15 @@ class S2SAppendSession implements TransportAppendSession {
 
 		this.http2Stream = stream;
 
-		this.options?.signal?.addEventListener("abort", () => {
+		// Store the handler so close() can remove it. A caller-provided signal
+		// can outlive many sessions (RetryAppendSession recreates a session per
+		// recovery, reusing the same signal), so an unremovable listener leaks.
+		this.abortHandler = () => {
 			if (!stream.closed) {
 				stream.close();
 			}
-		});
+		};
+		this.options?.signal?.addEventListener("abort", this.abortHandler);
 
 		const textDecoder = new TextDecoder();
 		let responseCode: number | undefined;
@@ -915,6 +920,7 @@ class S2SAppendSession implements TransportAppendSession {
 		});
 
 		stream.on("close", () => {
+			this.removeAbortListener();
 			// Stream closed - resolve any remaining pending acks with error
 			// This can happen if the server closes the stream without sending all acks
 			if (this.pendingAcks.length > 0) {
@@ -996,6 +1002,14 @@ class S2SAppendSession implements TransportAppendSession {
 	 * Waits for all pending appends to complete before resolving.
 	 * Never throws - returns CloseResult.
 	 */
+	/** Remove the abort listener from the caller-provided signal, if attached. */
+	private removeAbortListener(): void {
+		if (this.abortHandler && this.options?.signal) {
+			this.options.signal.removeEventListener("abort", this.abortHandler);
+		}
+		this.abortHandler = undefined;
+	}
+
 	async close(): Promise<CloseResult> {
 		try {
 			this.closed = true;
@@ -1009,6 +1023,10 @@ class S2SAppendSession implements TransportAppendSession {
 			if (this.initPromise) {
 				await this.initPromise.catch(() => {});
 			}
+
+			// Detach from the caller-provided signal (init has now run, so the
+			// handler is registered if it ever will be).
+			this.removeAbortListener();
 
 			// Wait for all pending acks to complete
 			while (this.pendingAcks.length > 0) {

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -997,11 +997,6 @@ class S2SAppendSession implements TransportAppendSession {
 		return this._effectSignalled;
 	}
 
-	/**
-	 * Close the append session.
-	 * Waits for all pending appends to complete before resolving.
-	 * Never throws - returns CloseResult.
-	 */
 	/** Remove the abort listener from the caller-provided signal, if attached. */
 	private removeAbortListener(): void {
 		if (this.abortHandler && this.options?.signal) {
@@ -1010,6 +1005,11 @@ class S2SAppendSession implements TransportAppendSession {
 		this.abortHandler = undefined;
 	}
 
+	/**
+	 * Close the append session.
+	 * Waits for all pending appends to complete before resolving.
+	 * Never throws - returns CloseResult.
+	 */
 	async close(): Promise<CloseResult> {
 		try {
 			this.closed = true;


### PR DESCRIPTION
## Summary

Fixes #307. `S2SAppendSession` attached an `"abort"` listener to the caller-provided `AbortSignal` that could never be removed, leaking listeners across retries.

## The bug

`initializeStream()` registered the handler with an anonymous arrow function (`index.ts:777`), so there was no reference to pass to `removeEventListener`, and `close()` had no cleanup. The signal is shared across sessions:

- `S2STransport.makeAppendSession` builds a generator closure that captures one `requestOptions` — and thus one `.signal` (`index.ts:100-111`).
- `RetryAppendSession.ensureSession()` re-invokes that generator on every recovery (`retry.ts:1447→1504`), so each recreated `S2SAppendSession` reuses the same signal.
- Each session's first `submit()` adds another anonymous listener; none are ever removed. Listeners — plus the closures retaining the abandoned sessions and their HTTP/2 streams — accumulate per recovery, unbounded because `RetryConfig.maxAttempts` is uncapped.

This is the same class of bug that #142 fixed for `S2SReadSession`, which already stores an `abortHandler` and removes it on cleanup (`index.ts:264-268`). The append path was missed.

## The fix

- Store the handler on the instance (`private abortHandler?`) instead of passing an anonymous function.
- Remove it via a `removeAbortListener()` helper in `close()` — placed after the `initPromise` await added in #306, so the handler is guaranteed registered before removal — and also on the stream's `"close"` event as a backstop, so the listener detaches even if a session's stream closes without an explicit `close()`.

## Testing

`bun run check` (typecheck) clean. Ran the transport/append/retry/pool unit suites — 52 tests pass (`s2s-transport`, `appendSession`, `retryAppendSession`, `retry`, `h2-pool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)