### PR TITLE
fix: clear ping-timeout timer when fetch read wins the race (#308)

### DIFF
--- a/packages/streamstore/src/lib/stream/transport/fetch/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/fetch/index.ts
@@ -241,6 +241,7 @@ export class FetchReadSession<Format extends "string" | "bytes" = "string">
 					}
 					const currentRead = pendingRead;
 
+					let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 					try {
 						// Race reader.read() against timeout
 						// If timeout fires but activity happened since scheduling, it's "stale" and we retry
@@ -249,8 +250,8 @@ export class FetchReadSession<Format extends "string" | "bytes" = "string">
 								pendingRead = null;
 								return { type: "data" as const, value: r };
 							}),
-							new Promise<RaceResult>((resolve) =>
-								setTimeout(() => {
+							new Promise<RaceResult>((resolve) => {
+								timeoutHandle = setTimeout(() => {
 									if (lastPingTimeMs === capturedLastPingTime) {
 										// No activity since timeout was scheduled - actually timed out
 										debug("read session ping timeout");
@@ -259,8 +260,8 @@ export class FetchReadSession<Format extends "string" | "bytes" = "string">
 										// Activity happened - this timeout is stale, retry with new timeout.
 										resolve({ type: "stale" });
 									}
-								}, remainingTimeMs),
-							),
+								}, remainingTimeMs);
+							}),
 						]);
 
 						if (result.type === "stale") {
@@ -317,6 +318,8 @@ export class FetchReadSession<Format extends "string" | "bytes" = "string">
 						await cancelReader(error);
 						controller.close();
 						return;
+					} finally {
+						if (timeoutHandle) clearTimeout(timeoutHandle);
 					}
 				}
 			},


### PR DESCRIPTION
## Summary

Fixes #308. `FetchReadSession.pull` raced `reader.read()` against a ping-timeout `setTimeout` whose handle was never captured or cleared. When data won the race (the common case), the timer stayed pending until it fired ~25s later. It isn't `unref`'d, so it kept the Node event loop alive for up to ~25s after a session drained, and under high read throughput the pending timers accumulated transiently.

No correctness impact — the late firing only resolved an already-settled, unawaited promise — so this is resource hygiene.

## Change

Capture the `setTimeout` handle and `clearTimeout` it in a `finally` around the existing race. This matches the pattern already used in `retry.ts` (`waitForHead`). The `finally` also covers the `stale` retry path (`continue`), clearing each fired timer before the next loop iteration schedules a new one.

## Testing

`bun run check` clean; full streamstore unit suite passes (438 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)