### PR TITLE
Make TCP_NODELAY explicit for s2s transport

### DIFF
--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -8,7 +8,11 @@
  */
 
 import type { OutgoingHttpHeaders } from "node:http";
-import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
+import type {
+	ClientHttp2Session,
+	ClientHttp2Stream,
+	ClientSessionOptions,
+} from "node:http2";
 import createDebug from "debug";
 import { S2Error } from "../../../../error.js";
 import type { Http2Settings } from "../../types.js";
@@ -57,6 +61,9 @@ function endpointKey(origin: string, settings: ResolvedHttp2Settings): string {
 }
 
 type Http2Module = typeof import("node:http2");
+// Node forwards this socket option through http2.connect, but @types/node
+// does not currently include it on ClientSessionOptions.
+type Http2ConnectOptions = ClientSessionOptions & { noDelay: boolean };
 
 let http2ModulePromise: Promise<Http2Module> | undefined;
 async function loadHttp2(): Promise<Http2Module> {
@@ -281,7 +288,8 @@ export class Http2ConnectionPool {
 		const { origin, settings } = endpoint;
 		debug("connecting to %s", origin);
 		const http2 = await loadHttp2();
-		const session = http2.connect(origin, {
+		const connectOptions: Http2ConnectOptions = {
+			noDelay: true,
 			// Headroom above the flow-control windows so Node's session memory
 			// cap (default 10 MB) does not refuse streams when windows are raised.
 			// This is just a heuristic to avoid memory issues in case.
@@ -296,7 +304,8 @@ export class Http2ConnectionPool {
 			settings: {
 				initialWindowSize: settings.initialStreamWindowSize,
 			},
-		});
+		};
+		const session = http2.connect(origin, connectOptions);
 
 		try {
 			// Each pooled stream may add its own session listeners (e.g. goaway).


### PR DESCRIPTION
## Summary
- Pass `noDelay: true` into the shared S2S HTTP/2 connection pool.
- Keep this non-configurable; it is a latency-oriented transport default, not a public SDK option.

## Socket verification
I verified before/after behavior against built JS from:

- Before: `origin/main` at `a432527`
- After: this branch at `6710515`

For Node and Bun, I inspected the live client socket with `getsockopt(TCP_NODELAY)` using a small local C helper, with the socket fd inherited into the helper process. For Deno, Node-compat sockets do not expose an OS fd, so I inspected Deno's internal `Symbol(kSetNoDelay)` state instead. Deno and Bun normally fall back to the fetch transport in SDK runtime detection; those checks force the low-level S2S HTTP/2 pool directly.

| Runtime | Inspection | Raw control | Before | After | Result |
| --- | --- | --- | --- | --- | --- |
| Node `v24.14.0` | `getsockopt(TCP_NODELAY)` | `false=0`, `true=4` | `4` | `4` | no behavior change |
| Node `v22.22.0` | `getsockopt(TCP_NODELAY)` | `false=0`, `true=4` | `4` | `4` | no behavior change |
| Bun `1.3.14` | `getsockopt(TCP_NODELAY)` | `false=4`, `true=4` | `4` | `4` | no behavior change; Bun raw socket control could not force disabled |
| Deno `2.9.3` | `Symbol(kSetNoDelay)` | `false=false`, `true=true` | `true` | `true` | no behavior change in compat state |

Conclusion: every runtime checked already has the S2S HTTP/2 pool socket in TCP_NODELAY/no-delay state before this change. This PR makes that option explicit in our `http2.connect` call rather than relying on runtime-specific implicit behavior.

## Validation
- `bun run --cwd packages/streamstore test src/tests/h2-pool.test.ts`
- `bun run --cwd packages/streamstore check`
- `bun run check`
- Local before/after socket inspection described above