### PR TITLE
chore: extract transport-neutral caught-up tracker

### DIFF
--- a/packages/streamstore/src/index.ts
+++ b/packages/streamstore/src/index.ts
@@ -182,6 +182,11 @@ export {
 export type { StreamOptions } from "./basin.js";
 export type { BatchOutput, BatchTransformOptions } from "./batch-transform.js";
 export type {
+	CaughtUpBatch,
+	CaughtUpBoundary,
+} from "./lib/stream/caught-up-tracker.js";
+export { CaughtUpTracker } from "./lib/stream/caught-up-tracker.js";
+export type {
 	AcksStream,
 	AppendHeaders,
 	AppendSession,

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -13,6 +13,10 @@ import { isCommandRecord, meteredBytes } from "../utils.js";
 import { FifoQueue } from "./queue.js";
 import type { AppendResult, CloseResult } from "./result.js";
 import { err, errClose, ok, okClose } from "./result.js";
+import {
+	type CaughtUpBoundary,
+	CaughtUpTracker,
+} from "./stream/caught-up-tracker.js";
 import type {
 	AcksStream,
 	AppendRecord,
@@ -229,25 +233,10 @@ export async function withRetries<T>(
 
 	throw lastError;
 }
-/** Error a pending `caughtUp()` settles with when the session ends first. */
-function sessionClosedError(): S2Error {
-	return new S2Error({
-		message: "Read session ended before catching up",
-		code: "SESSION_CLOSED",
-		status: 0,
-		origin: "sdk",
-	});
-}
-
-type CaughtUpWaiter = {
-	resolve: (tail: Types.StreamPosition) => void;
-	reject: (error: S2Error) => void;
-};
-
 type ReadDelivery<Format extends "string" | "bytes"> = {
 	records: Types.ReadRecord<Format>[];
 	next: number;
-	caughtUpTail?: API.StreamPosition;
+	boundary?: CaughtUpBoundary;
 	onDrained?: () => void;
 };
 
@@ -262,41 +251,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 	private _recordsRead: number = 0;
 	private _bytesRead: number = 0;
 
-	private _isCaughtUp = false;
-	private _caughtUpTail: API.StreamPosition | undefined = undefined;
-	private caughtUpWaiters: CaughtUpWaiter[] = [];
-	private terminal: { error?: S2Error } | undefined = undefined;
-
-	/** Mark caught up and resolve pending waits with this tail. */
-	private markCaughtUp(tail: API.StreamPosition): void {
-		this._isCaughtUp = true;
-		this._caughtUpTail = tail;
-		const waiters = this.caughtUpWaiters.splice(0);
-		const position = toSDKStreamPosition(tail);
-		for (const waiter of waiters) {
-			waiter.resolve(position);
-		}
-	}
-
-	private markBehind(): void {
-		this._isCaughtUp = false;
-	}
-
-	/** End the session and reject pending waits. Clean ends preserve caught-up state. */
-	private settleTerminal(error?: S2Error): void {
-		if (this.terminal) {
-			return;
-		}
-		this.terminal = { error };
-		if (error) {
-			this._isCaughtUp = false;
-		}
-		const waiters = this.caughtUpWaiters.splice(0);
-		const rejection = error ?? sessionClosedError();
-		for (const waiter of waiters) {
-			waiter.reject(rejection);
-		}
-	}
+	private readonly caughtUpTracker: CaughtUpTracker;
 
 	static async create<Format extends "string" | "bytes" = "string">(
 		generator: (
@@ -361,6 +316,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			...config,
 		};
 		const format = (args?.as ?? "string") as Format;
+		const caughtUpTracker = new CaughtUpTracker();
 		let session: TransportReadSession<Format> | undefined = initialSession;
 		let currentReader:
 			| ReadableStreamDefaultReader<TransportReadEvent<Format>>
@@ -379,9 +335,9 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 		};
 		const enqueueBatch = async (
 			records: Types.ReadRecord<Format>[],
-			caughtUpTail?: API.StreamPosition,
+			boundary?: CaughtUpBoundary,
 		) => {
-			if (!caughtUpTail) {
+			if (!boundary) {
 				if (records.length > 0) {
 					deliveries.push({ records, next: 0 });
 					wake();
@@ -391,14 +347,14 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			await new Promise<void>((onDrained) => {
 				resolvePendingDelivery = onDrained;
 				if (records.length === 0 && deliveries.length === 0) {
-					this.markCaughtUp(caughtUpTail);
+					boundary.markDelivered();
 					onDrained();
 					return;
 				}
 				deliveries.push({
 					records,
 					next: 0,
-					caughtUpTail,
+					boundary,
 					onDrained,
 				});
 				wake();
@@ -406,7 +362,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			resolvePendingDelivery = undefined;
 		};
 		const failPump = (error: S2Error) => {
-			this.settleTerminal(error);
+			caughtUpTracker.end(error);
 			pumpError = error;
 			deliveries.clear();
 			wake();
@@ -504,7 +460,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 					if (done || cancelled) {
 						reader.releaseLock();
 						currentReader = undefined;
-						this.settleTerminal();
+						caughtUpTracker.end();
 						pumpDone = true;
 						wake();
 						return;
@@ -549,7 +505,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 									nextArgs.wait = baselineWait;
 								}
 							}
-							this.markBehind();
+							caughtUpTracker.reconnect();
 
 							try {
 								await session.cancel?.("retry");
@@ -580,15 +536,13 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 						return;
 					}
 
-					this.markBehind();
 					const { records, tail } = result.batch;
 					const lastRecord = records.at(-1);
-					const caughtUpTail =
-						tail &&
-						(lastRecord === undefined ||
-							lastRecord.seq_num + 1 === tail.seq_num)
-							? tail
-							: undefined;
+					const boundary = caughtUpTracker.observeBatch({
+						recordCount: records.length,
+						lastSeqNum: lastRecord?.seq_num,
+						tail: tail ? toSDKStreamPosition(tail) : undefined,
+					});
 					const visibleRecords: Types.ReadRecord<Format>[] = [];
 					for (const record of records) {
 						this._nextReadPosition = {
@@ -602,14 +556,12 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 							visibleRecords.push(toSDKReadRecord(record, format));
 						}
 					}
-					await enqueueBatch(visibleRecords, caughtUpTail);
+					await enqueueBatch(visibleRecords, boundary);
 				}
 			}
 		};
 		const finishDelivery = (delivery: ReadDelivery<Format>) => {
-			if (delivery.caughtUpTail) {
-				this.markCaughtUp(delivery.caughtUpTail);
-			}
+			delivery.boundary?.markDelivered();
 			delivery.onDrained?.();
 		};
 
@@ -654,7 +606,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 				},
 				cancel: async (reason) => {
 					cancelled = true;
-					this.settleTerminal();
+					caughtUpTracker.end();
 					pumpDone = true;
 					deliveries.clear();
 					resolvePendingDelivery?.();
@@ -676,6 +628,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			},
 			{ highWaterMark: 0 },
 		);
+		this.caughtUpTracker = caughtUpTracker;
 	}
 
 	async [Symbol.asyncDispose]() {
@@ -743,22 +696,11 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 	}
 
 	isCaughtUp(): boolean {
-		return this._isCaughtUp;
+		return this.caughtUpTracker.isCaughtUp();
 	}
 
 	caughtUp(): Promise<Types.StreamPosition> {
-		if (this._isCaughtUp && this._caughtUpTail) {
-			return Promise.resolve(toSDKStreamPosition(this._caughtUpTail));
-		}
-		if (this.terminal) {
-			return Promise.reject(this.terminal.error ?? sessionClosedError());
-		}
-		const promise = new Promise<Types.StreamPosition>((resolve, reject) => {
-			this.caughtUpWaiters.push({ resolve, reject });
-		});
-		// Prevent an unhandled rejection when the promise is ignored.
-		promise.catch(() => {});
-		return promise;
+		return this.caughtUpTracker.caughtUp();
 	}
 }
 

--- a/packages/streamstore/src/lib/stream/caught-up-tracker.ts
+++ b/packages/streamstore/src/lib/stream/caught-up-tracker.ts
@@ -51,14 +51,18 @@ function sessionClosedError(): S2Error {
 }
 
 class Boundary implements CaughtUpBoundary {
-	readonly tail: StreamPosition;
+	private readonly caughtUpTail: StreamPosition;
 	private delivered = false;
 
 	constructor(
-		private readonly caughtUpTail: StreamPosition,
+		caughtUpTail: StreamPosition,
 		private readonly deliver: (tail: StreamPosition) => void,
 	) {
-		this.tail = copyPosition(caughtUpTail);
+		this.caughtUpTail = copyPosition(caughtUpTail);
+	}
+
+	get tail(): StreamPosition {
+		return copyPosition(this.caughtUpTail);
 	}
 
 	markDelivered(): void {
@@ -94,17 +98,19 @@ export class CaughtUpTracker {
 		this.caughtUpTail = undefined;
 
 		const tail = input.tail;
+		if (tail === undefined) {
+			return undefined;
+		}
 		const reachesTail =
-			tail !== undefined &&
-			(input.recordCount === 0 ||
-				(input.recordCount > 0 &&
-					input.lastSeqNum !== undefined &&
-					input.lastSeqNum + 1 === tail.seqNum));
-		if (!reachesTail || tail === undefined) {
+			input.recordCount === 0 ||
+			(input.recordCount > 0 &&
+				input.lastSeqNum !== undefined &&
+				input.lastSeqNum + 1 === tail.seqNum);
+		if (!reachesTail) {
 			return undefined;
 		}
 
-		return new Boundary(copyPosition(tail), (caughtUpTail) => {
+		return new Boundary(tail, (caughtUpTail) => {
 			this.markDelivered(revision, caughtUpTail);
 		});
 	}
@@ -167,7 +173,7 @@ export class CaughtUpTracker {
 			return;
 		}
 
-		this.caughtUpTail = copyPosition(tail);
+		this.caughtUpTail = tail;
 		const waiters = this.waiters.splice(0);
 		for (const waiter of waiters) {
 			waiter.resolve(copyPosition(tail));

--- a/packages/streamstore/src/lib/stream/caught-up-tracker.ts
+++ b/packages/streamstore/src/lib/stream/caught-up-tracker.ts
@@ -1,0 +1,176 @@
+import { S2Error } from "../../error.js";
+import type { StreamPosition } from "../../types.js";
+
+/**
+ * A caught-up point observed in the input stream but not necessarily delivered
+ * to the consumer yet.
+ */
+export interface CaughtUpBoundary {
+	/** The tail reported for this caught-up point. */
+	readonly tail: StreamPosition;
+
+	/**
+	 * Mark every visible record preceding this boundary as delivered.
+	 *
+	 * Repeated calls and calls made stale by a newer batch, reconnect, or
+	 * terminal state are no-ops.
+	 */
+	markDelivered(): void;
+}
+
+/** A normalized decoded batch or heartbeat observed by a read client. */
+export interface CaughtUpBatch {
+	/** Number of records before any client-side filtering. */
+	readonly recordCount: number;
+	/** Sequence number of the final unfiltered record, when present. */
+	readonly lastSeqNum?: number;
+	/** Tail reported with the batch or heartbeat, when present. */
+	readonly tail?: StreamPosition;
+}
+
+type CaughtUpWaiter = {
+	resolve: (tail: StreamPosition) => void;
+	reject: (error: S2Error) => void;
+};
+
+function copyPosition(position: StreamPosition): StreamPosition {
+	return {
+		seqNum: position.seqNum,
+		timestamp: new Date(position.timestamp.getTime()),
+	};
+}
+
+/** Error a pending {@link CaughtUpTracker.caughtUp} call rejects with on a clean end. */
+function sessionClosedError(): S2Error {
+	return new S2Error({
+		message: "Read session ended before catching up",
+		code: "SESSION_CLOSED",
+		status: 0,
+		origin: "sdk",
+	});
+}
+
+class Boundary implements CaughtUpBoundary {
+	readonly tail: StreamPosition;
+	private delivered = false;
+
+	constructor(
+		private readonly caughtUpTail: StreamPosition,
+		private readonly deliver: (tail: StreamPosition) => void,
+	) {
+		this.tail = copyPosition(caughtUpTail);
+	}
+
+	markDelivered(): void {
+		if (this.delivered) {
+			return;
+		}
+		this.delivered = true;
+		this.deliver(this.caughtUpTail);
+	}
+}
+
+/**
+ * Tracks whether normalized read batches have reached a reported tail and have
+ * been delivered through that point.
+ *
+ * Transport clients call {@link observeBatch} as soon as they decode a batch
+ * or heartbeat. Delivery is a separate step: the returned boundary is marked
+ * only after all preceding visible records have been consumed. Pending
+ * {@link caughtUp} calls survive reconnects, while terminal states settle them.
+ */
+export class CaughtUpTracker {
+	private revision = 0;
+	private caughtUpTail: StreamPosition | undefined;
+	private waiters: CaughtUpWaiter[] = [];
+	private terminal: { error?: S2Error } | undefined;
+
+	observeBatch(input: CaughtUpBatch): CaughtUpBoundary | undefined {
+		if (this.terminal) {
+			return undefined;
+		}
+
+		const revision = ++this.revision;
+		this.caughtUpTail = undefined;
+
+		const tail = input.tail;
+		const reachesTail =
+			tail !== undefined &&
+			(input.recordCount === 0 ||
+				(input.recordCount > 0 &&
+					input.lastSeqNum !== undefined &&
+					input.lastSeqNum + 1 === tail.seqNum));
+		if (!reachesTail || tail === undefined) {
+			return undefined;
+		}
+
+		return new Boundary(copyPosition(tail), (caughtUpTail) => {
+			this.markDelivered(revision, caughtUpTail);
+		});
+	}
+
+	/** Mark the tracker behind and invalidate boundaries from the old connection. */
+	reconnect(): void {
+		if (this.terminal) {
+			return;
+		}
+		this.revision++;
+		this.caughtUpTail = undefined;
+	}
+
+	/**
+	 * End tracking and settle pending waiters.
+	 *
+	 * A clean end preserves an already caught-up state. An error clears it.
+	 */
+	end(error?: S2Error): void {
+		if (this.terminal) {
+			return;
+		}
+
+		this.revision++;
+		this.terminal = { error };
+		if (error) {
+			this.caughtUpTail = undefined;
+		}
+
+		const waiters = this.waiters.splice(0);
+		const rejection = error ?? sessionClosedError();
+		for (const waiter of waiters) {
+			waiter.reject(rejection);
+		}
+	}
+
+	isCaughtUp(): boolean {
+		return this.caughtUpTail !== undefined;
+	}
+
+	caughtUp(): Promise<StreamPosition> {
+		if (this.caughtUpTail) {
+			return Promise.resolve(copyPosition(this.caughtUpTail));
+		}
+		if (this.terminal) {
+			return Promise.reject(this.terminal.error ?? sessionClosedError());
+		}
+
+		const promise = new Promise<StreamPosition>((resolve, reject) => {
+			this.waiters.push({ resolve, reject });
+		});
+		// A caller may intentionally use only isCaughtUp(); do not report the
+		// tracker's terminal settlement as an unhandled rejection in that case.
+		promise.catch(() => {});
+		return promise;
+	}
+
+	private markDelivered(revision: number, tail: StreamPosition): void {
+		if (this.terminal || revision !== this.revision) {
+			return;
+		}
+
+		this.caughtUpTail = copyPosition(tail);
+		const waiters = this.waiters.splice(0);
+		for (const waiter of waiters) {
+			waiter.resolve(copyPosition(tail));
+		}
+	}
+}

--- a/packages/streamstore/src/tests/caughtUpTracker.test.ts
+++ b/packages/streamstore/src/tests/caughtUpTracker.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import { S2Error } from "../error.js";
+import { CaughtUpTracker } from "../lib/stream/caught-up-tracker.js";
+import type { StreamPosition } from "../types.js";
+
+const tailAt = (seqNum: number): StreamPosition => ({
+	seqNum,
+	timestamp: new Date(seqNum * 1000),
+});
+
+describe("CaughtUpTracker", () => {
+	it("settles multiple waiters only after a caught-up boundary is delivered", async () => {
+		const tracker = new CaughtUpTracker();
+		const first = tracker.caughtUp();
+		const second = tracker.caughtUp();
+		const settled = vi.fn();
+		void first.then(settled, settled);
+		void second.then(settled, settled);
+
+		const boundary = tracker.observeBatch({
+			recordCount: 2,
+			lastSeqNum: 4,
+			tail: tailAt(5),
+		});
+
+		expect(boundary?.tail).toEqual(tailAt(5));
+		expect(tracker.isCaughtUp()).toBe(false);
+		expect(settled).not.toHaveBeenCalled();
+
+		boundary?.markDelivered();
+
+		await expect(first).resolves.toEqual(tailAt(5));
+		await expect(second).resolves.toEqual(tailAt(5));
+		expect(tracker.isCaughtUp()).toBe(true);
+		await expect(tracker.caughtUp()).resolves.toEqual(tailAt(5));
+	});
+
+	it("represents an empty heartbeat as an immediately drainable boundary", async () => {
+		const tracker = new CaughtUpTracker();
+		const caughtUp = tracker.caughtUp();
+
+		const boundary = tracker.observeBatch({
+			recordCount: 0,
+			tail: tailAt(12),
+		});
+
+		expect(boundary).toBeDefined();
+		expect(tracker.isCaughtUp()).toBe(false);
+
+		boundary?.markDelivered();
+
+		await expect(caughtUp).resolves.toEqual(tailAt(12));
+		expect(tracker.isCaughtUp()).toBe(true);
+	});
+
+	it("uses the unfiltered final sequence number to establish a boundary", async () => {
+		const tracker = new CaughtUpTracker();
+		const caughtUp = tracker.caughtUp();
+
+		// The second raw record is a filtered command record. The delivery layer
+		// retains this boundary with the one remaining visible record.
+		const boundary = tracker.observeBatch({
+			recordCount: 2,
+			lastSeqNum: 1,
+			tail: tailAt(2),
+		});
+
+		expect(boundary).toBeDefined();
+		expect(tracker.isCaughtUp()).toBe(false);
+
+		// Simulates draining the remaining visible record.
+		boundary?.markDelivered();
+		await expect(caughtUp).resolves.toEqual(tailAt(2));
+	});
+
+	it("marks itself behind when a batch does not establish a boundary", async () => {
+		const tracker = new CaughtUpTracker();
+		tracker.observeBatch({ recordCount: 0, tail: tailAt(3) })?.markDelivered();
+		expect(tracker.isCaughtUp()).toBe(true);
+
+		expect(
+			tracker.observeBatch({
+				recordCount: 1,
+				lastSeqNum: 3,
+				tail: tailAt(5),
+			}),
+		).toBeUndefined();
+		expect(tracker.isCaughtUp()).toBe(false);
+
+		const pending = tracker.caughtUp();
+		const settled = vi.fn();
+		void pending.then(settled, settled);
+		await Promise.resolve();
+		expect(settled).not.toHaveBeenCalled();
+
+		tracker.observeBatch({ recordCount: 0, tail: tailAt(5) })?.markDelivered();
+		await expect(pending).resolves.toEqual(tailAt(5));
+	});
+
+	it("allows only the newest observed boundary to transition the state", async () => {
+		const tracker = new CaughtUpTracker();
+		const caughtUp = tracker.caughtUp();
+		const settled = vi.fn();
+		void caughtUp.then(settled, settled);
+
+		const older = tracker.observeBatch({
+			recordCount: 1,
+			lastSeqNum: 0,
+			tail: tailAt(1),
+		});
+		const newer = tracker.observeBatch({
+			recordCount: 1,
+			lastSeqNum: 1,
+			tail: tailAt(2),
+		});
+
+		older?.markDelivered();
+		await Promise.resolve();
+		expect(tracker.isCaughtUp()).toBe(false);
+		expect(settled).not.toHaveBeenCalled();
+
+		newer?.markDelivered();
+		await expect(caughtUp).resolves.toEqual(tailAt(2));
+
+		// Delivery handles are idempotent.
+		newer?.markDelivered();
+		expect(tracker.isCaughtUp()).toBe(true);
+	});
+
+	it("keeps waiters pending across reconnect and ignores stale boundaries", async () => {
+		const tracker = new CaughtUpTracker();
+		const caughtUp = tracker.caughtUp();
+		const settled = vi.fn();
+		void caughtUp.then(settled, settled);
+		const stale = tracker.observeBatch({
+			recordCount: 0,
+			tail: tailAt(8),
+		});
+
+		tracker.reconnect();
+		stale?.markDelivered();
+		await Promise.resolve();
+		expect(tracker.isCaughtUp()).toBe(false);
+		expect(settled).not.toHaveBeenCalled();
+
+		tracker.observeBatch({ recordCount: 0, tail: tailAt(9) })?.markDelivered();
+		await expect(caughtUp).resolves.toEqual(tailAt(9));
+	});
+
+	it("rejects pending waiters on a clean end and invalidates boundaries", async () => {
+		const tracker = new CaughtUpTracker();
+		const caughtUp = tracker.caughtUp();
+		const stale = tracker.observeBatch({
+			recordCount: 0,
+			tail: tailAt(4),
+		});
+
+		tracker.end();
+		stale?.markDelivered();
+
+		await expect(caughtUp).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+		await expect(tracker.caughtUp()).rejects.toMatchObject({
+			code: "SESSION_CLOSED",
+		});
+		expect(tracker.isCaughtUp()).toBe(false);
+		expect(
+			tracker.observeBatch({ recordCount: 0, tail: tailAt(5) }),
+		).toBeUndefined();
+	});
+
+	it("preserves an already caught-up state on a clean end", async () => {
+		const tracker = new CaughtUpTracker();
+		tracker.observeBatch({ recordCount: 0, tail: tailAt(6) })?.markDelivered();
+
+		tracker.end();
+
+		expect(tracker.isCaughtUp()).toBe(true);
+		await expect(tracker.caughtUp()).resolves.toEqual(tailAt(6));
+	});
+
+	it("clears caught-up state and rejects waiters with a terminal error", async () => {
+		const tracker = new CaughtUpTracker();
+		tracker.observeBatch({ recordCount: 0, tail: tailAt(6) })?.markDelivered();
+		tracker.observeBatch({ recordCount: 1, lastSeqNum: 6 });
+		const caughtUp = tracker.caughtUp();
+		const error = new S2Error({ message: "read failed", status: 503 });
+
+		tracker.end(error);
+
+		await expect(caughtUp).rejects.toBe(error);
+		await expect(tracker.caughtUp()).rejects.toBe(error);
+		expect(tracker.isCaughtUp()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- extract `isCaughtUp()` / `caughtUp()` lifecycle behavior into a transport-neutral `CaughtUpTracker`
- represent observed caught-up points as delivery boundaries that transition only after preceding visible records drain
- invalidate stale boundaries after newer observations, reconnects, and terminal states
- keep raw sequence accounting ahead of command-record filtering
- export the tracker for normalized SSE or other direct read clients

## Why

The retrying read-session wrapper previously owned waiter settlement, reconnect behavior, termination, tail comparison, and delivery ordering alongside transport retry and queue mechanics. Moving those state transitions into a focused component makes the invariants independently testable and reusable without coupling them to Fetch, S2S, or `ReadableStream` construction.

The read-session delivery layer now retains the returned boundary beside visible records and calls `markDelivered()` when that queue entry drains. Empty heartbeats use the same path, while filtered command records still contribute their unfiltered final sequence number.

## Validation

- `bunx vitest --run packages/streamstore/src/tests/caughtUpTracker.test.ts packages/streamstore/src/tests/retryReadSession.test.ts` — 30 tests passed
- `bunx vitest --run packages/streamstore/src/tests/h2-pool.test.ts` — 13 tests passed
- `bun run --cwd packages/streamstore check`
- Biome checks on all changed files
- `git diff --check`
