### PR TITLE
fix(streamstore): make read cancellation idempotent

### DIFF
--- a/.changeset/calm-read-cancellation.md
+++ b/.changeset/calm-read-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Prevent S2S read cancellation from enqueuing into a closed stream controller when HTTP/2 closes with a partial frame.

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -236,13 +236,25 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		const parser = new S2SFrameParser();
 		const textDecoder = new TextDecoder();
 		let http2Stream: ClientHttp2Stream | undefined;
+		let controllerClosed = false;
+		let cleanupListeners: (() => void) | undefined;
 		// Track timeout for detecting when server stops sending data
 		const TAIL_TIMEOUT_MS = 20000; // 20 seconds
 		let timeoutTimer: NodeJS.Timeout | undefined;
+		const markControllerClosed = () => {
+			if (controllerClosed) return false;
+			controllerClosed = true;
+			cleanupListeners?.();
+			cleanupListeners = undefined;
+			if (timeoutTimer) {
+				clearTimeout(timeoutTimer);
+				timeoutTimer = undefined;
+			}
+			return true;
+		};
 
 		super({
 			start: async (controller) => {
-				let controllerClosed = false;
 				let responseCode: number | undefined;
 				let pendingChunks: Buffer[] | undefined;
 
@@ -257,7 +269,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					| undefined;
 				let sessionConnection: Http2Session | undefined;
 
-				const cleanupListeners = () => {
+				cleanupListeners = () => {
 					if (abortHandler && options?.signal) {
 						options.signal.removeEventListener("abort", abortHandler);
 					}
@@ -270,13 +282,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					sessionConnection = undefined;
 				};
 				const safeClose = () => {
-					if (!controllerClosed) {
-						controllerClosed = true;
-						cleanupListeners();
-						if (timeoutTimer) {
-							clearTimeout(timeoutTimer);
-							timeoutTimer = undefined;
-						}
+					if (markControllerClosed()) {
 						try {
 							controller.close();
 						} catch {
@@ -285,13 +291,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					}
 				};
 				const safeError = (err: unknown) => {
-					if (!controllerClosed) {
-						controllerClosed = true;
-						cleanupListeners();
-						if (timeoutTimer) {
-							clearTimeout(timeoutTimer);
-							timeoutTimer = undefined;
-						}
+					if (markControllerClosed()) {
 						// Convert error to S2Error and enqueue as error result
 						controller.enqueue({ ok: false, error: s2Error(err) });
 						controller.close();
@@ -362,6 +362,10 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					});
 
 					http2Stream = stream;
+					if (controllerClosed) {
+						stream.close();
+						return;
+					}
 
 					abortHandler = () => {
 						if (!stream.closed) {
@@ -583,6 +587,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 				}
 			},
 			cancel: async () => {
+				markControllerClosed();
 				if (http2Stream && !http2Stream.closed) {
 					http2Stream.close();
 				}

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -192,9 +192,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 	extends ReadableStream<TransportReadEvent<Format>>
 	implements TransportReadSession<Format>
 {
-	private http2Stream?: ClientHttp2Stream;
 	private _lastObservedTail?: API.StreamPosition;
-	private parser = new S2SFrameParser();
 
 	static async create<Format extends "string" | "bytes" = "string">(
 		baseUrl: string,
@@ -232,7 +230,6 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		private encryptionKey?: Redacted.Redacted<string>,
 		private compression: CompressionType = "none",
 	) {
-		// Initialize parser and textDecoder before super() call
 		const parser = new S2SFrameParser();
 		const textDecoder = new TextDecoder();
 		let http2Stream: ClientHttp2Stream | undefined;
@@ -398,6 +395,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					});
 
 					const processChunk = (chunk: Buffer) => {
+						if (controllerClosed) return;
 						try {
 							const status = responseCode ?? 500;
 							if (status >= 400) {
@@ -593,10 +591,6 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 				}
 			},
 		});
-
-		// Assign parser to instance property after super() completes
-		this.parser = parser;
-		this.http2Stream = http2Stream;
 	}
 
 	/**

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -444,6 +444,39 @@ describe("S2STransport http2 settings", () => {
 	);
 });
 
+describe("S2STransport read cancellation", () => {
+	it(
+		"does not enqueue after cancellation closes a partial frame",
+		async () => {
+			let resolveStreamStarted: (() => void) | undefined;
+			const streamStarted = new Promise<void>((resolve) => {
+				resolveStreamStarted = resolve;
+			});
+			const server = await startServer((stream) => {
+				stream.write(Buffer.from([0, 0, 8, 0, 1]));
+				resolveStreamStarted?.();
+			});
+
+			try {
+				const transport = new S2STransport({
+					baseUrl: `${server.origin}/v1`,
+					accessToken: Redacted.make("test-token"),
+				});
+				const session = await transport.makeReadSession("test-stream");
+				await streamStarted;
+				await sleep(50);
+
+				await session.cancel();
+				await sleep(50);
+				await transport.close();
+			} finally {
+				await server.close().catch(() => {});
+			}
+		},
+		TEST_TIMEOUT_MS,
+	);
+});
+
 describe("S2STransport connection sharing", () => {
 	it(
 		"shares one connection across transports and closes it on last close",


### PR DESCRIPTION
## What changed

- Make S2S read cancellation share the same idempotent controller-close transition as transport completion and errors.
- Close a late HTTP/2 stream immediately when cancellation wins before stream creation completes.
- Skip frame processing entirely once the controller is marked closed, instead of relying on catch blocks to swallow closed-controller enqueues.
- Drop the write-only `http2Stream`/`parser` instance fields from `S2SReadSession` (they were assigned before `start`'s async body populated the locals, so they were permanently `undefined`/unused).
- Add a regression test that cancels while a partial S2S frame is buffered.
- Add a patch changeset for `@s2-dev/streamstore`.

## Why

Canceling the Web `ReadableStream` closes its controller. A later HTTP/2 close callback could still observe a partial frame and enqueue an SDK error into that closed controller. Node then raised `ERR_INVALID_STATE` as an unhandled process error.

The append path does not need an equivalent fix: the transport-level append session has no ReadableStream (acks resolve promises from a FIFO queue, so late callbacks are harmless), and the retry-level `acks()` stream already wraps every controller operation in try/catch.

## Impact

Consumers can cancel S2S reads, including after closing a downstream pipe, without a late transport callback crashing the process.

## Validation

- Regression test verified against the unfixed code: it reproduces the unhandled `ERR_INVALID_STATE` and fails the run (exit 1); passes with the fix.
- `bunx vitest run packages/streamstore/src/tests/h2-pool.test.ts`
- `bun run check`
- `bun run test:core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)