### PR TITLE
feat(streamstore): add durable producer flush

### DIFF
--- a/.changeset/quiet-producers-flush.md
+++ b/.changeset/quiet-producers-flush.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": minor
+---
+
+Add a durable, non-terminal `Producer.flush()` boundary.

--- a/packages/streamstore/src/batch-transform.ts
+++ b/packages/streamstore/src/batch-transform.ts
@@ -68,7 +68,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 				this.handleRecord(chunk);
 			},
 			flush: () => {
-				this.flush();
+				this.flushBatch();
 			},
 			cancel: () => {
 				this.cancelLingerTimer();
@@ -154,7 +154,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 			this.currentBatchSize + recordSize > this.maxBatchBytes;
 
 		if (wouldExceedRecords || wouldExceedBytes) {
-			this.flush();
+			this.flushBatch();
 			// Restart linger timer for new batch
 			if (this.lingerDuration >= 0) {
 				this.startLingerTimer();
@@ -170,11 +170,30 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 		const nowExceedsBytes = this.currentBatchSize >= this.maxBatchBytes;
 
 		if (nowExceedsRecords || nowExceedsBytes) {
-			this.flush();
+			this.flushBatch();
 		}
 	}
 
-	private flush(): void {
+	/**
+	 * Emit the current partial batch immediately.
+	 *
+	 * This does not wait for the batch to be appended or acknowledged. Use
+	 * `Producer.flush()` when a durable boundary is required.
+	 */
+	flush(): void {
+		try {
+			this.flushBatch();
+		} catch (err) {
+			try {
+				this.controller?.error(err);
+			} catch {
+				// Controller may already be closed or errored.
+			}
+			throw err;
+		}
+	}
+
+	private flushBatch(): void {
 		this.cancelLingerTimer();
 
 		if (this.currentBatch.length === 0) {
@@ -208,7 +227,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 			this.lingerTimer = null;
 			if (this.currentBatch.length > 0) {
 				try {
-					this.flush();
+					this.flushBatch();
 				} catch (err) {
 					if (err instanceof TypeError) {
 						// Stream lifecycle issue (closed/errored controller) — safe to discard.

--- a/packages/streamstore/src/batch-transform.ts
+++ b/packages/streamstore/src/batch-transform.ts
@@ -68,7 +68,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 				this.handleRecord(chunk);
 			},
 			flush: () => {
-				this.flushBatch();
+				this.flushCurrentBatch();
 			},
 			cancel: () => {
 				this.cancelLingerTimer();
@@ -154,7 +154,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 			this.currentBatchSize + recordSize > this.maxBatchBytes;
 
 		if (wouldExceedRecords || wouldExceedBytes) {
-			this.flushBatch();
+			this.flushCurrentBatch();
 			// Restart linger timer for new batch
 			if (this.lingerDuration >= 0) {
 				this.startLingerTimer();
@@ -170,7 +170,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 		const nowExceedsBytes = this.currentBatchSize >= this.maxBatchBytes;
 
 		if (nowExceedsRecords || nowExceedsBytes) {
-			this.flushBatch();
+			this.flushCurrentBatch();
 		}
 	}
 
@@ -182,7 +182,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 	 */
 	flush(): void {
 		try {
-			this.flushBatch();
+			this.flushCurrentBatch();
 		} catch (err) {
 			try {
 				this.controller?.error(err);
@@ -193,7 +193,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 		}
 	}
 
-	private flushBatch(): void {
+	private flushCurrentBatch(): void {
 		this.cancelLingerTimer();
 
 		if (this.currentBatch.length === 0) {
@@ -227,7 +227,7 @@ export class BatchTransform extends TransformStream<AppendRecord, BatchOutput> {
 			this.lingerTimer = null;
 			if (this.currentBatch.length > 0) {
 				try {
-					this.flushBatch();
+					this.flushCurrentBatch();
 				} catch (err) {
 					if (err instanceof TypeError) {
 						// Stream lifecycle issue (closed/errored controller) — safe to discard.

--- a/packages/streamstore/src/producer.ts
+++ b/packages/streamstore/src/producer.ts
@@ -44,10 +44,7 @@ export class RecordSubmitTicket {
 	}
 }
 
-/**
- * Internal record tracking - only needs ack callbacks since submit() resolves
- * based on backpressure from the transform stream write.
- */
+/** Record state shared by FIFO batch association and acknowledgement tracking. */
 type InflightRecord = {
 	ackPromise: Promise<IndexedAppendAck>;
 	resolveAck: (ack: IndexedAppendAck) => void;
@@ -95,15 +92,15 @@ export class Producer implements AsyncDisposable {
 	readonly writable: WritableStream<AppendRecord>;
 
 	private readonly inflightRecords: InflightRecord[] = [];
-	private readonly pendingRecords = new Set<InflightRecord>();
+	private readonly pendingAckEntries = new Set<InflightRecord>();
 
-	private pumpError: S2Error | null = null;
+	private terminalError: S2Error | null = null;
 	private readableController: ReadableStreamDefaultController<IndexedAppendAck> | null =
 		null;
 
 	private readonly debugName: string;
 	private submitCounter = 0;
-	private operationTail: Promise<void> = Promise.resolve();
+	private operationChain: Promise<void> = Promise.resolve();
 	private closePromise: Promise<void> | null = null;
 
 	constructor(
@@ -140,7 +137,7 @@ export class Producer implements AsyncDisposable {
 				await this.close();
 			},
 			abort: async (reason) => {
-				this.failProducer(reason);
+				this.fail(reason);
 				await this.close();
 			},
 		});
@@ -153,7 +150,7 @@ export class Producer implements AsyncDisposable {
 	 */
 	private async runPump(): Promise<void> {
 		debugProducer("[%s] pump started", this.debugName);
-		const pendingAcks = new Set<Promise<void>>();
+		const pendingAckHandlers = new Set<Promise<void>>();
 
 		try {
 			while (true) {
@@ -162,13 +159,13 @@ export class Producer implements AsyncDisposable {
 				if (done) {
 					debugProducer("[%s] pump done (transform closed)", this.debugName);
 					// Await all pending ack handlers before exiting
-					if (!this.pumpError && pendingAcks.size > 0) {
+					if (!this.terminalError && pendingAckHandlers.size > 0) {
 						debugProducer(
 							"[%s] pump awaiting %d pending acks",
 							this.debugName,
-							pendingAcks.size,
+							pendingAckHandlers.size,
 						);
-						await Promise.all(pendingAcks);
+						await Promise.all(pendingAckHandlers);
 					}
 					break;
 				}
@@ -211,7 +208,7 @@ export class Producer implements AsyncDisposable {
 
 					debugProducer("[%s] pump submit returned ticket", this.debugName);
 				} catch (err) {
-					const error = this.failProducer(err);
+					const error = this.fail(err);
 					debugProducer(
 						"[%s] pump submit error: %s",
 						this.debugName,
@@ -246,7 +243,7 @@ export class Producer implements AsyncDisposable {
 						}
 					})
 					.catch((err) => {
-						const error = this.failProducer(err);
+						const error = this.fail(err);
 						debugProducer(
 							"[%s] pump ack error: %s",
 							this.debugName,
@@ -254,17 +251,17 @@ export class Producer implements AsyncDisposable {
 						);
 					})
 					.finally(() => {
-						pendingAcks.delete(ackHandler);
+						pendingAckHandlers.delete(ackHandler);
 					});
-				pendingAcks.add(ackHandler);
+				pendingAckHandlers.add(ackHandler);
 			}
 
 			// After the loop exits with an error, cancel the transform reader
 			// so pending transformWriter.write() calls are unblocked (they will
 			// reject, causing submit() to throw). Then reject any remaining
 			// inflight records whose ack promises would otherwise hang.
-			if (this.pumpError) {
-				this.transformReader.cancel(this.pumpError).catch(() => {});
+			if (this.terminalError) {
+				this.transformReader.cancel(this.terminalError).catch(() => {});
 
 				if (this.inflightRecords.length > 0) {
 					debugProducer(
@@ -273,12 +270,12 @@ export class Producer implements AsyncDisposable {
 						this.inflightRecords.length,
 					);
 					for (const record of this.inflightRecords.splice(0)) {
-						record.rejectAck(this.pumpError);
+						record.rejectAck(this.terminalError);
 					}
 				}
 			}
 		} catch (err) {
-			const error = this.failProducer(err);
+			const error = this.fail(err);
 			debugProducer(
 				"[%s] pump caught error: %s",
 				this.debugName,
@@ -299,10 +296,10 @@ export class Producer implements AsyncDisposable {
 	 * @throws S2Error if the Producer has failed
 	 */
 	submit(record: AppendRecord): Promise<RecordSubmitTicket> {
-		return this.enqueueOperation(() => this.submitRecord(record));
+		return this.enqueueOperation(() => this.submitInternal(record));
 	}
 
-	private async submitRecord(
+	private async submitInternal(
 		record: AppendRecord,
 	): Promise<RecordSubmitTicket> {
 		const submitId = ++this.submitCounter;
@@ -314,15 +311,15 @@ export class Producer implements AsyncDisposable {
 			this.inflightRecords.length,
 		);
 
-		// Pump already failed: rethrow the original error (as close() does)
+		// The Producer already failed: rethrow the original error (as close() does)
 		// so its type is preserved.
-		if (this.pumpError) {
+		if (this.terminalError) {
 			debugProducer(
-				"[%s] submit #%d: pump already failed",
+				"[%s] submit #%d: producer already failed",
 				this.debugName,
 				submitId,
 			);
-			throw this.pumpError;
+			throw this.terminalError;
 		}
 
 		// Create the ack promise (resolved later by pump)
@@ -336,10 +333,10 @@ export class Producer implements AsyncDisposable {
 		ackPromise.catch(() => {});
 		// Track this record
 		const entry: InflightRecord = { ackPromise, resolveAck, rejectAck };
-		this.pendingRecords.add(entry);
+		this.pendingAckEntries.add(entry);
 		void ackPromise.then(
-			() => this.pendingRecords.delete(entry),
-			() => this.pendingRecords.delete(entry),
+			() => this.pendingAckEntries.delete(entry),
+			() => this.pendingAckEntries.delete(entry),
 		);
 		this.inflightRecords.push(entry);
 
@@ -373,7 +370,7 @@ export class Producer implements AsyncDisposable {
 				this.inflightRecords.splice(idx, 1);
 			}
 
-			const error = this.failProducer(err);
+			const error = this.fail(err);
 			throw error;
 		}
 
@@ -387,28 +384,29 @@ export class Producer implements AsyncDisposable {
 	 *
 	 * An empty flush does not append a batch. Submissions queued after this call
 	 * are excluded, and the Producer remains open for further submissions. If a
-	 * covered append fails, this throws the same terminal error as its record ticket.
+	 * append included in this flush fails, this throws the same terminal error as
+	 * its record ticket.
 	 */
 	flush(): Promise<void> {
 		return this.enqueueOperation(async () => {
-			if (this.pumpError) {
-				throw this.pumpError;
+			if (this.terminalError) {
+				throw this.terminalError;
 			}
 
-			const coveredAcks = [...this.pendingRecords].map(
-				(record) => record.ackPromise,
+			const pendingAckPromises = [...this.pendingAckEntries].map(
+				(entry) => entry.ackPromise,
 			);
 			try {
 				this.batchTransform.flush();
 			} catch (err) {
-				const error = this.failProducer(err);
-				await Promise.allSettled(coveredAcks);
+				const error = this.fail(err);
+				await Promise.allSettled(pendingAckPromises);
 				throw error;
 			}
-			await Promise.allSettled(coveredAcks);
+			await Promise.allSettled(pendingAckPromises);
 
-			if (this.pumpError) {
-				throw this.pumpError;
+			if (this.terminalError) {
+				throw this.terminalError;
 			}
 		});
 	}
@@ -423,27 +421,27 @@ export class Producer implements AsyncDisposable {
 		if (this.closePromise) {
 			return this.closePromise;
 		}
-		this.closePromise = this.enqueueOperation(() => this._doClose());
+		this.closePromise = this.enqueueOperation(() => this.closeInternal());
 		return this.closePromise;
 	}
 
 	private enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
-		const result = this.operationTail.then(operation);
-		this.operationTail = result.then(
+		const operationPromise = this.operationChain.then(operation);
+		this.operationChain = operationPromise.then(
 			() => undefined,
 			() => undefined,
 		);
-		return result;
+		return operationPromise;
 	}
 
-	private failProducer(err: unknown): S2Error {
-		if (!this.pumpError) {
-			this.pumpError = toS2Error(err);
+	private fail(cause: unknown): S2Error {
+		if (!this.terminalError) {
+			this.terminalError = toS2Error(cause);
 		}
-		const error = this.pumpError;
+		const error = this.terminalError;
 
-		for (const record of this.pendingRecords) {
-			record.rejectAck(error);
+		for (const entry of this.pendingAckEntries) {
+			entry.rejectAck(error);
 		}
 		this.transformReader.cancel(error).catch(() => {});
 
@@ -457,7 +455,7 @@ export class Producer implements AsyncDisposable {
 		return error;
 	}
 
-	private async _doClose(): Promise<void> {
+	private async closeInternal(): Promise<void> {
 		debugProducer("[%s] close requested", this.debugName);
 
 		// Close the writer to signal no more records.
@@ -465,7 +463,7 @@ export class Producer implements AsyncDisposable {
 		try {
 			await this.transformWriter.close();
 		} catch {
-			// Writer already errored from pump failure — that's fine.
+			// Writer already errored from a terminal failure — that's fine.
 		}
 
 		// Wait for the pump to finish processing all batches
@@ -476,7 +474,7 @@ export class Producer implements AsyncDisposable {
 
 		// Reject any remaining inflight records (shouldn't happen in normal operation)
 		if (this.inflightRecords.length > 0) {
-			this.failProducer(
+			this.fail(
 				new S2Error({
 					message: "Producer closed with pending records",
 					status: 499,
@@ -499,8 +497,8 @@ export class Producer implements AsyncDisposable {
 		debugProducer("[%s] close complete", this.debugName);
 
 		// If an error occurred, throw it
-		if (this.pumpError) {
-			throw this.pumpError;
+		if (this.terminalError) {
+			throw this.terminalError;
 		}
 	}
 

--- a/packages/streamstore/src/producer.ts
+++ b/packages/streamstore/src/producer.ts
@@ -49,6 +49,7 @@ export class RecordSubmitTicket {
  * based on backpressure from the transform stream write.
  */
 type InflightRecord = {
+	ackPromise: Promise<IndexedAppendAck>;
 	resolveAck: (ack: IndexedAppendAck) => void;
 	rejectAck: (err: S2Error) => void;
 };
@@ -60,6 +61,8 @@ type InflightRecord = {
  *   has been accepted (written to the batch transform). Backpressure is applied
  *   automatically via the transform stream when the AppendSession is at capacity.
  * - ticket.ack() returns a Promise<IndexedAppendAck> that resolves once the record is durable.
+ * - flush() emits the current partial batch and waits for all records submitted before it
+ *   to become durable, without closing the Producer.
  *
  * See the "Producer API" section of the root README for guidance on sizing batches,
  * wiring transforms, and handling application-level ids.
@@ -92,6 +95,7 @@ export class Producer implements AsyncDisposable {
 	readonly writable: WritableStream<AppendRecord>;
 
 	private readonly inflightRecords: InflightRecord[] = [];
+	private readonly pendingRecords = new Set<InflightRecord>();
 
 	private pumpError: S2Error | null = null;
 	private readableController: ReadableStreamDefaultController<IndexedAppendAck> | null =
@@ -99,6 +103,7 @@ export class Producer implements AsyncDisposable {
 
 	private readonly debugName: string;
 	private submitCounter = 0;
+	private operationTail: Promise<void> = Promise.resolve();
 	private closePromise: Promise<void> | null = null;
 
 	constructor(
@@ -135,7 +140,7 @@ export class Producer implements AsyncDisposable {
 				await this.close();
 			},
 			abort: async (reason) => {
-				this.pumpError = toS2Error(reason);
+				this.failProducer(reason);
 				await this.close();
 			},
 		});
@@ -157,7 +162,7 @@ export class Producer implements AsyncDisposable {
 				if (done) {
 					debugProducer("[%s] pump done (transform closed)", this.debugName);
 					// Await all pending ack handlers before exiting
-					if (pendingAcks.size > 0) {
+					if (!this.pumpError && pendingAcks.size > 0) {
 						debugProducer(
 							"[%s] pump awaiting %d pending acks",
 							this.debugName,
@@ -206,30 +211,12 @@ export class Producer implements AsyncDisposable {
 
 					debugProducer("[%s] pump submit returned ticket", this.debugName);
 				} catch (err) {
-					const error = toS2Error(err);
+					const error = this.failProducer(err);
 					debugProducer(
 						"[%s] pump submit error: %s",
 						this.debugName,
 						error.message,
 					);
-
-					if (!this.pumpError) {
-						this.pumpError = error;
-					}
-
-					// Reject acks for records in this batch
-					for (const record of associatedRecords) {
-						record.rejectAck(error);
-					}
-
-					try {
-						if (this.readableController) {
-							this.readableController.error(error);
-							this.readableController = null;
-						}
-					} catch {
-						// Controller may be closed/errored
-					}
 
 					break;
 				}
@@ -259,29 +246,12 @@ export class Producer implements AsyncDisposable {
 						}
 					})
 					.catch((err) => {
-						const error = toS2Error(err);
+						const error = this.failProducer(err);
 						debugProducer(
 							"[%s] pump ack error: %s",
 							this.debugName,
 							error.message,
 						);
-
-						if (!this.pumpError) {
-							this.pumpError = error;
-						}
-
-						for (const record of associatedRecords) {
-							record.rejectAck(error);
-						}
-
-						try {
-							if (this.readableController) {
-								this.readableController.error(error);
-								this.readableController = null;
-							}
-						} catch {
-							// Controller may be closed/errored
-						}
 					})
 					.finally(() => {
 						pendingAcks.delete(ackHandler);
@@ -308,27 +278,14 @@ export class Producer implements AsyncDisposable {
 				}
 			}
 		} catch (err) {
-			const error = toS2Error(err);
+			const error = this.failProducer(err);
 			debugProducer(
 				"[%s] pump caught error: %s",
 				this.debugName,
 				error.message,
 			);
 
-			if (!this.pumpError) {
-				this.pumpError = error;
-			}
-
-			// Reject all remaining inflight records
-			for (const record of this.inflightRecords.splice(0)) {
-				record.rejectAck(error);
-			}
-
-			// Error the readable stream
-			if (this.readableController) {
-				this.readableController.error(error);
-				this.readableController = null;
-			}
+			this.inflightRecords.splice(0);
 		}
 	}
 
@@ -341,7 +298,13 @@ export class Producer implements AsyncDisposable {
 	 *
 	 * @throws S2Error if the Producer has failed
 	 */
-	async submit(record: AppendRecord): Promise<RecordSubmitTicket> {
+	submit(record: AppendRecord): Promise<RecordSubmitTicket> {
+		return this.enqueueOperation(() => this.submitRecord(record));
+	}
+
+	private async submitRecord(
+		record: AppendRecord,
+	): Promise<RecordSubmitTicket> {
 		const submitId = ++this.submitCounter;
 
 		debugProducer(
@@ -371,9 +334,13 @@ export class Producer implements AsyncDisposable {
 		});
 		// Suppress unhandled rejection if write fails before we return the ticket
 		ackPromise.catch(() => {});
-
 		// Track this record
-		const entry: InflightRecord = { resolveAck, rejectAck };
+		const entry: InflightRecord = { ackPromise, resolveAck, rejectAck };
+		this.pendingRecords.add(entry);
+		void ackPromise.then(
+			() => this.pendingRecords.delete(entry),
+			() => this.pendingRecords.delete(entry),
+		);
 		this.inflightRecords.push(entry);
 
 		debugProducer(
@@ -406,13 +373,44 @@ export class Producer implements AsyncDisposable {
 				this.inflightRecords.splice(idx, 1);
 			}
 
-			const error = toS2Error(err);
-			rejectAck(error);
+			const error = this.failProducer(err);
 			throw error;
 		}
 
 		// Write succeeded - return ticket immediately
 		return new RecordSubmitTicket(ackPromise);
+	}
+
+	/**
+	 * Force the current partial batch to be emitted and wait for every record
+	 * submitted before this call to become durable.
+	 *
+	 * An empty flush does not append a batch. Submissions queued after this call
+	 * are excluded, and the Producer remains open for further submissions. If a
+	 * covered append fails, this throws the same terminal error as its record ticket.
+	 */
+	flush(): Promise<void> {
+		return this.enqueueOperation(async () => {
+			if (this.pumpError) {
+				throw this.pumpError;
+			}
+
+			const coveredAcks = [...this.pendingRecords].map(
+				(record) => record.ackPromise,
+			);
+			try {
+				this.batchTransform.flush();
+			} catch (err) {
+				const error = this.failProducer(err);
+				await Promise.allSettled(coveredAcks);
+				throw error;
+			}
+			await Promise.allSettled(coveredAcks);
+
+			if (this.pumpError) {
+				throw this.pumpError;
+			}
+		});
 	}
 
 	/**
@@ -425,8 +423,38 @@ export class Producer implements AsyncDisposable {
 		if (this.closePromise) {
 			return this.closePromise;
 		}
-		this.closePromise = this._doClose();
+		this.closePromise = this.enqueueOperation(() => this._doClose());
 		return this.closePromise;
+	}
+
+	private enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.operationTail.then(operation);
+		this.operationTail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
+	private failProducer(err: unknown): S2Error {
+		if (!this.pumpError) {
+			this.pumpError = toS2Error(err);
+		}
+		const error = this.pumpError;
+
+		for (const record of this.pendingRecords) {
+			record.rejectAck(error);
+		}
+		this.transformReader.cancel(error).catch(() => {});
+
+		try {
+			this.readableController?.error(error);
+		} catch {
+			// Controller may already be closed or errored.
+		}
+		this.readableController = null;
+
+		return error;
 	}
 
 	private async _doClose(): Promise<void> {
@@ -448,15 +476,14 @@ export class Producer implements AsyncDisposable {
 
 		// Reject any remaining inflight records (shouldn't happen in normal operation)
 		if (this.inflightRecords.length > 0) {
-			const closingError = new S2Error({
-				message: "Producer closed with pending records",
-				status: 499,
-				origin: "sdk",
-			});
-
-			for (const record of this.inflightRecords.splice(0)) {
-				record.rejectAck(closingError);
-			}
+			this.failProducer(
+				new S2Error({
+					message: "Producer closed with pending records",
+					status: 499,
+					origin: "sdk",
+				}),
+			);
+			this.inflightRecords.splice(0);
 		}
 
 		// Close the readable stream

--- a/packages/streamstore/src/tests/producer.test.ts
+++ b/packages/streamstore/src/tests/producer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { BatchTransform } from "../batch-transform.js";
+import { S2Error } from "../error.js";
 import { AppendRecord } from "../index.js";
 import {
 	type AcksStream,
@@ -146,6 +147,109 @@ class AsyncMockAppendSession implements AppendSession {
 	}
 }
 
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+type ControlledAppendCall = {
+	input: AppendInput;
+	ack: Deferred<AppendAck>;
+};
+
+class ControlledAppendSession implements AppendSession {
+	readonly readable = new ReadableStream<AppendAck>();
+	readonly writable = new WritableStream<AppendInput>();
+	private readonly acksStream = new ReadableStream<AppendAck>() as AcksStream;
+	private readonly calls: ControlledAppendCall[] = [];
+	private readonly callWaiters: Array<(call: ControlledAppendCall) => void> =
+		[];
+	private readonly submitFailure?: { call: number; error: S2Error };
+
+	submitCount = 0;
+
+	constructor(submitFailure?: { call: number; error: S2Error }) {
+		this.submitFailure = submitFailure;
+	}
+
+	async submit(input: AppendInput): Promise<BatchSubmitTicket> {
+		const call = { input, ack: deferred<AppendAck>() };
+		this.submitCount += 1;
+		const waiter = this.callWaiters.shift();
+		if (waiter) {
+			waiter(call);
+		} else {
+			this.calls.push(call);
+		}
+
+		if (this.submitFailure?.call === this.submitCount) {
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			throw this.submitFailure.error;
+		}
+
+		return new BatchSubmitTicket(call.ack.promise, 0, input.records.length);
+	}
+
+	nextCall(): Promise<ControlledAppendCall> {
+		const call = this.calls.shift();
+		if (call) {
+			return Promise.resolve(call);
+		}
+		return new Promise((resolve) => this.callWaiters.push(resolve));
+	}
+
+	async close(): Promise<void> {}
+
+	acks(): AcksStream {
+		return this.acksStream;
+	}
+
+	lastAckedPosition(): AppendAck | undefined {
+		return undefined;
+	}
+
+	failureCause(): S2Error | undefined {
+		return this.submitFailure?.error;
+	}
+
+	async [Symbol.asyncDispose](): Promise<void> {
+		await this.close();
+	}
+}
+
+function appendAck(start: number, records: number): AppendAck {
+	return {
+		start: { seqNum: start, timestamp: new Date(0) },
+		end: { seqNum: start + records, timestamp: new Date(0) },
+		tail: { seqNum: start + records, timestamp: new Date(0) },
+	};
+}
+
+async function expectPending(promise: Promise<unknown>): Promise<void> {
+	const pending = Symbol("pending");
+	const state = await Promise.race([
+		promise.then(
+			() => "fulfilled" as const,
+			() => "rejected" as const,
+		),
+		new Promise<typeof pending>((resolve) =>
+			setTimeout(() => resolve(pending), 10),
+		),
+	]);
+	expect(state).toBe(pending);
+}
+
 describe("Producer", () => {
 	it("preserves record order when batching", async () => {
 		const session = new MockAppendSession();
@@ -190,4 +294,123 @@ describe("Producer", () => {
 
 		expect(session.getValues()).toEqual(["rec-0", "rec-1", "rec-2", "rec-3"]);
 	});
+
+	it("flush emits a partial batch and waits for every covered ack", async () => {
+		const session = new ControlledAppendSession();
+		const producer = new Producer(
+			new BatchTransform({
+				lingerDurationMillis: 60_000,
+				maxBatchRecords: 2,
+			}),
+			session,
+		);
+
+		const tickets = await Promise.all([
+			producer.submit(AppendRecord.string({ body: "a" })),
+			producer.submit(AppendRecord.string({ body: "b" })),
+			producer.submit(AppendRecord.string({ body: "c" })),
+		]);
+		const fullBatch = await session.nextCall();
+		const flush = producer.flush();
+		const partialBatch = await session.nextCall();
+
+		expect(fullBatch.input.records).toHaveLength(2);
+		expect(partialBatch.input.records).toHaveLength(1);
+
+		const fullBatchAck = appendAck(41, 2);
+		fullBatch.ack.resolve(fullBatchAck);
+		await Promise.all([tickets[0].ack(), tickets[1].ack()]);
+		await expectPending(flush);
+
+		const partialBatchAck = appendAck(43, 1);
+		partialBatch.ack.resolve(partialBatchAck);
+		await flush;
+
+		const recordAcks = await Promise.all(tickets.map((ticket) => ticket.ack()));
+		expect(recordAcks.map((ack) => ack.seqNum())).toEqual([41, 42, 43]);
+		expect(recordAcks[0]?.batchAppendAck()).toBe(fullBatchAck);
+		expect(recordAcks[1]?.batchAppendAck()).toBe(fullBatchAck);
+		expect(recordAcks[2]?.batchAppendAck()).toBe(partialBatchAck);
+
+		await producer.close();
+	});
+
+	it("flush is an empty-safe, reusable prefix boundary", async () => {
+		const session = new ControlledAppendSession();
+		const producer = new Producer(
+			new BatchTransform({
+				lingerDurationMillis: 60_000,
+				maxBatchRecords: 100,
+			}),
+			session,
+		);
+
+		await producer.flush();
+		expect(session.submitCount).toBe(0);
+
+		const firstTicket = await producer.submit(
+			AppendRecord.string({ body: "before" }),
+		);
+		const firstFlush = producer.flush();
+		const firstCall = await session.nextCall();
+		const laterTicketPromise = producer.submit(
+			AppendRecord.string({ body: "after" }),
+		);
+
+		firstCall.ack.resolve(appendAck(0, 1));
+		await firstFlush;
+		const laterTicket = await laterTicketPromise;
+		expect((await firstTicket.ack()).seqNum()).toBe(0);
+		expect(session.submitCount).toBe(1);
+
+		const secondFlush = producer.flush();
+		const secondCall = await session.nextCall();
+		secondCall.ack.resolve(appendAck(1, 1));
+		await secondFlush;
+		expect((await laterTicket.ack()).seqNum()).toBe(1);
+
+		await producer.close();
+	});
+
+	it.each(["submit", "ack"] as const)(
+		"flush propagates a covered %s failure",
+		async (failurePhase) => {
+			const error = new S2Error({
+				message: `${failurePhase} failed`,
+				status: 412,
+				origin: "server",
+			});
+			const session = new ControlledAppendSession(
+				failurePhase === "submit" ? { call: 2, error } : undefined,
+			);
+			const producer = new Producer(
+				new BatchTransform({
+					lingerDurationMillis: 60_000,
+					maxBatchRecords: 1,
+				}),
+				session,
+			);
+
+			const firstTicket = await producer.submit(
+				AppendRecord.string({ body: "first" }),
+			);
+			const secondTicket = await producer.submit(
+				AppendRecord.string({ body: "second" }),
+			);
+			await session.nextCall();
+			const failingCall = await session.nextCall();
+			const flush = producer.flush();
+			if (failurePhase === "ack") {
+				failingCall.ack.reject(error);
+			}
+
+			await Promise.all([
+				expect(firstTicket.ack()).rejects.toBe(error),
+				expect(secondTicket.ack()).rejects.toBe(error),
+				expect(flush).rejects.toBe(error),
+			]);
+			await expect(producer.flush()).rejects.toBe(error);
+			await expect(producer.close()).rejects.toBe(error);
+		},
+	);
 });

--- a/packages/streamstore/src/tests/producer.test.ts
+++ b/packages/streamstore/src/tests/producer.test.ts
@@ -168,7 +168,7 @@ type PendingSubmission = {
 	ack: Deferred<AppendAck>;
 };
 
-class ManualAppendSession implements AppendSession {
+class ControlledAppendSession implements AppendSession {
 	readonly readable = new ReadableStream<AppendAck>();
 	readonly writable = new WritableStream<AppendInput>();
 	private readonly acksStream = new ReadableStream<AppendAck>() as AcksStream;
@@ -301,7 +301,7 @@ describe("Producer", () => {
 	});
 
 	it("flush emits the current partial batch and waits for all prior acks", async () => {
-		const session = new ManualAppendSession();
+		const session = new ControlledAppendSession();
 		const producer = new Producer(
 			new BatchTransform({
 				lingerDurationMillis: 60_000,
@@ -341,7 +341,7 @@ describe("Producer", () => {
 	});
 
 	it("flush is reusable, does nothing when empty, and excludes later submissions", async () => {
-		const session = new ManualAppendSession();
+		const session = new ControlledAppendSession();
 		const producer = new Producer(
 			new BatchTransform({
 				lingerDurationMillis: 60_000,
@@ -385,7 +385,7 @@ describe("Producer", () => {
 				status: 412,
 				origin: "server",
 			});
-			const session = new ManualAppendSession(
+			const session = new ControlledAppendSession(
 				failurePhase === "submit" ? { submitNumber: 2, error } : undefined,
 			);
 			const producer = new Producer(

--- a/packages/streamstore/src/tests/producer.test.ts
+++ b/packages/streamstore/src/tests/producer.test.ts
@@ -163,50 +163,55 @@ function deferred<T>(): Deferred<T> {
 	return { promise, resolve, reject };
 }
 
-type ControlledAppendCall = {
+type PendingSubmission = {
 	input: AppendInput;
 	ack: Deferred<AppendAck>;
 };
 
-class ControlledAppendSession implements AppendSession {
+class ManualAppendSession implements AppendSession {
 	readonly readable = new ReadableStream<AppendAck>();
 	readonly writable = new WritableStream<AppendInput>();
 	private readonly acksStream = new ReadableStream<AppendAck>() as AcksStream;
-	private readonly calls: ControlledAppendCall[] = [];
-	private readonly callWaiters: Array<(call: ControlledAppendCall) => void> =
-		[];
-	private readonly submitFailure?: { call: number; error: S2Error };
+	private readonly pendingSubmissions: PendingSubmission[] = [];
+	private readonly submissionWaiters: Array<
+		(submission: PendingSubmission) => void
+	> = [];
+	private readonly submitFailure?: { submitNumber: number; error: S2Error };
 
-	submitCount = 0;
+	submissionCount = 0;
 
-	constructor(submitFailure?: { call: number; error: S2Error }) {
+	constructor(submitFailure?: { submitNumber: number; error: S2Error }) {
 		this.submitFailure = submitFailure;
 	}
 
 	async submit(input: AppendInput): Promise<BatchSubmitTicket> {
-		const call = { input, ack: deferred<AppendAck>() };
-		this.submitCount += 1;
-		const waiter = this.callWaiters.shift();
+		const submission = { input, ack: deferred<AppendAck>() };
+		this.submissionCount += 1;
+		const waiter = this.submissionWaiters.shift();
 		if (waiter) {
-			waiter(call);
+			waiter(submission);
 		} else {
-			this.calls.push(call);
+			this.pendingSubmissions.push(submission);
 		}
 
-		if (this.submitFailure?.call === this.submitCount) {
+		if (this.submitFailure?.submitNumber === this.submissionCount) {
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 			throw this.submitFailure.error;
 		}
 
-		return new BatchSubmitTicket(call.ack.promise, 0, input.records.length);
+		return new BatchSubmitTicket(
+			submission.ack.promise,
+			0,
+			input.records.length,
+		);
 	}
 
-	nextCall(): Promise<ControlledAppendCall> {
-		const call = this.calls.shift();
-		if (call) {
-			return Promise.resolve(call);
+	nextSubmission(): Promise<PendingSubmission> {
+		const submission = this.pendingSubmissions.shift();
+		if (submission) {
+			return Promise.resolve(submission);
 		}
-		return new Promise((resolve) => this.callWaiters.push(resolve));
+		return new Promise((resolve) => this.submissionWaiters.push(resolve));
 	}
 
 	async close(): Promise<void> {}
@@ -228,11 +233,11 @@ class ControlledAppendSession implements AppendSession {
 	}
 }
 
-function appendAck(start: number, records: number): AppendAck {
+function makeAck(startSeqNum: number, recordCount: number): AppendAck {
 	return {
-		start: { seqNum: start, timestamp: new Date(0) },
-		end: { seqNum: start + records, timestamp: new Date(0) },
-		tail: { seqNum: start + records, timestamp: new Date(0) },
+		start: { seqNum: startSeqNum, timestamp: new Date(0) },
+		end: { seqNum: startSeqNum + recordCount, timestamp: new Date(0) },
+		tail: { seqNum: startSeqNum + recordCount, timestamp: new Date(0) },
 	};
 }
 
@@ -295,8 +300,8 @@ describe("Producer", () => {
 		expect(session.getValues()).toEqual(["rec-0", "rec-1", "rec-2", "rec-3"]);
 	});
 
-	it("flush emits a partial batch and waits for every covered ack", async () => {
-		const session = new ControlledAppendSession();
+	it("flush emits the current partial batch and waits for all prior acks", async () => {
+		const session = new ManualAppendSession();
 		const producer = new Producer(
 			new BatchTransform({
 				lingerDurationMillis: 60_000,
@@ -310,21 +315,21 @@ describe("Producer", () => {
 			producer.submit(AppendRecord.string({ body: "b" })),
 			producer.submit(AppendRecord.string({ body: "c" })),
 		]);
-		const fullBatch = await session.nextCall();
-		const flush = producer.flush();
-		const partialBatch = await session.nextCall();
+		const fullBatchSubmission = await session.nextSubmission();
+		const flushPromise = producer.flush();
+		const partialBatchSubmission = await session.nextSubmission();
 
-		expect(fullBatch.input.records).toHaveLength(2);
-		expect(partialBatch.input.records).toHaveLength(1);
+		expect(fullBatchSubmission.input.records).toHaveLength(2);
+		expect(partialBatchSubmission.input.records).toHaveLength(1);
 
-		const fullBatchAck = appendAck(41, 2);
-		fullBatch.ack.resolve(fullBatchAck);
+		const fullBatchAck = makeAck(41, 2);
+		fullBatchSubmission.ack.resolve(fullBatchAck);
 		await Promise.all([tickets[0].ack(), tickets[1].ack()]);
-		await expectPending(flush);
+		await expectPending(flushPromise);
 
-		const partialBatchAck = appendAck(43, 1);
-		partialBatch.ack.resolve(partialBatchAck);
-		await flush;
+		const partialBatchAck = makeAck(43, 1);
+		partialBatchSubmission.ack.resolve(partialBatchAck);
+		await flushPromise;
 
 		const recordAcks = await Promise.all(tickets.map((ticket) => ticket.ack()));
 		expect(recordAcks.map((ack) => ack.seqNum())).toEqual([41, 42, 43]);
@@ -335,8 +340,8 @@ describe("Producer", () => {
 		await producer.close();
 	});
 
-	it("flush is an empty-safe, reusable prefix boundary", async () => {
-		const session = new ControlledAppendSession();
+	it("flush is reusable, does nothing when empty, and excludes later submissions", async () => {
+		const session = new ManualAppendSession();
 		const producer = new Producer(
 			new BatchTransform({
 				lingerDurationMillis: 60_000,
@@ -346,42 +351,42 @@ describe("Producer", () => {
 		);
 
 		await producer.flush();
-		expect(session.submitCount).toBe(0);
+		expect(session.submissionCount).toBe(0);
 
 		const firstTicket = await producer.submit(
 			AppendRecord.string({ body: "before" }),
 		);
-		const firstFlush = producer.flush();
-		const firstCall = await session.nextCall();
+		const firstFlushPromise = producer.flush();
+		const firstSubmission = await session.nextSubmission();
 		const laterTicketPromise = producer.submit(
 			AppendRecord.string({ body: "after" }),
 		);
 
-		firstCall.ack.resolve(appendAck(0, 1));
-		await firstFlush;
+		firstSubmission.ack.resolve(makeAck(0, 1));
+		await firstFlushPromise;
 		const laterTicket = await laterTicketPromise;
 		expect((await firstTicket.ack()).seqNum()).toBe(0);
-		expect(session.submitCount).toBe(1);
+		expect(session.submissionCount).toBe(1);
 
-		const secondFlush = producer.flush();
-		const secondCall = await session.nextCall();
-		secondCall.ack.resolve(appendAck(1, 1));
-		await secondFlush;
+		const secondFlushPromise = producer.flush();
+		const secondSubmission = await session.nextSubmission();
+		secondSubmission.ack.resolve(makeAck(1, 1));
+		await secondFlushPromise;
 		expect((await laterTicket.ack()).seqNum()).toBe(1);
 
 		await producer.close();
 	});
 
 	it.each(["submit", "ack"] as const)(
-		"flush propagates a covered %s failure",
+		"flush propagates %s failures from prior submissions",
 		async (failurePhase) => {
 			const error = new S2Error({
 				message: `${failurePhase} failed`,
 				status: 412,
 				origin: "server",
 			});
-			const session = new ControlledAppendSession(
-				failurePhase === "submit" ? { call: 2, error } : undefined,
+			const session = new ManualAppendSession(
+				failurePhase === "submit" ? { submitNumber: 2, error } : undefined,
 			);
 			const producer = new Producer(
 				new BatchTransform({
@@ -397,17 +402,17 @@ describe("Producer", () => {
 			const secondTicket = await producer.submit(
 				AppendRecord.string({ body: "second" }),
 			);
-			await session.nextCall();
-			const failingCall = await session.nextCall();
-			const flush = producer.flush();
+			await session.nextSubmission();
+			const failingSubmission = await session.nextSubmission();
+			const flushPromise = producer.flush();
 			if (failurePhase === "ack") {
-				failingCall.ack.reject(error);
+				failingSubmission.ack.reject(error);
 			}
 
 			await Promise.all([
 				expect(firstTicket.ack()).rejects.toBe(error),
 				expect(secondTicket.ack()).rejects.toBe(error),
-				expect(flush).rejects.toBe(error),
+				expect(flushPromise).rejects.toBe(error),
 			]);
 			await expect(producer.flush()).rejects.toBe(error);
 			await expect(producer.close()).rejects.toBe(error);


### PR DESCRIPTION
Implements the TypeScript SDK portion of s2-streamstore/s2#666.

## What changed

- Add `Producer.flush()` as a durable, non-terminal prefix barrier.
- Force the current partial batch without waiting for linger or closing the producer.
- Exclude later submissions and keep the producer reusable after a successful flush.
- Propagate terminal submit and acknowledgment failures to the barrier and every covered record ticket.
- Document the emission-only `BatchTransform.flush()` distinction and add a minor Changeset.

## Why

Previously, closing the producer was the only way to force a partial batch and wait for durability. Applications needed a reusable durability boundary without ending the producer session.

## Validation

- `bun run --cwd packages/streamstore test` — 471 passed
- `bun run check`

The monorepo-wide test command passed all 569 tests but still reported two pre-existing unhandled `AbortError`s from the resumable-stream issue-234 test.