### PR TITLE
perf(streamstore): lazy-load protobuf codec

### DIFF
--- a/.changeset/lazy-protobuf-codec.md
+++ b/.changeset/lazy-protobuf-codec.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Defer loading the protobuf codec until a binary stream operation uses it.

--- a/packages/streamstore/src/lib/stream/transport/fetch/shared.ts
+++ b/packages/streamstore/src/lib/stream/transport/fetch/shared.ts
@@ -22,7 +22,13 @@ import type {
 	ReadBatch,
 } from "../../types.js";
 
-const loadProtoCodec = () => import("../proto.js");
+const loadProtoCodec = async () => {
+	try {
+		return await import("../proto.js");
+	} catch (error) {
+		throw s2Error(error);
+	}
+};
 
 type RequestOptionsWithHeaders = S2RequestOptions & {
 	headers?: Record<string, string>;

--- a/packages/streamstore/src/lib/stream/transport/fetch/shared.ts
+++ b/packages/streamstore/src/lib/stream/transport/fetch/shared.ts
@@ -21,12 +21,8 @@ import type {
 	ReadArgs,
 	ReadBatch,
 } from "../../types.js";
-import {
-	decodeProtoAppendAck,
-	decodeProtoReadBatch,
-	encodeProtoAppendInput,
-	protoAppendAckToJson,
-} from "../proto.js";
+
+const loadProtoCodec = () => import("../proto.js");
 
 type RequestOptionsWithHeaders = S2RequestOptions & {
 	headers?: Record<string, string>;
@@ -92,6 +88,7 @@ export async function streamRead<Format extends "string" | "bytes" = "string">(
 	}
 
 	if (wantsBytes) {
+		const { decodeProtoReadBatch } = await loadProtoCodec();
 		const batch = decodeProtoReadBatch(response.data as ArrayBuffer);
 		return batch as ReadBatch<Format>;
 	}
@@ -131,6 +128,11 @@ export async function streamAppend(
 	let response: any;
 
 	if (useProtobuf) {
+		const {
+			decodeProtoAppendAck,
+			encodeProtoAppendInput,
+			protoAppendAckToJson,
+		} = await loadProtoCodec();
 		const protoBody = encodeProtoAppendInput(input);
 
 		const headers = mergeHeaders(customHeaders, {

--- a/packages/streamstore/src/tests/bundle.browser.test.ts
+++ b/packages/streamstore/src/tests/bundle.browser.test.ts
@@ -51,4 +51,68 @@ describe("browser bundling", () => {
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps protobuf out of the initial chunk", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "streamstore-bundle-"));
+		try {
+			const entry = join(dir, "entry.ts");
+			writeFileSync(
+				entry,
+				[
+					`import { S2 } from ${JSON.stringify(join(pkgRoot, "src/index.ts"))};`,
+					`console.log(S2);`,
+				].join("\n"),
+			);
+
+			const result = await build({
+				entryPoints: [entry],
+				bundle: true,
+				platform: "browser",
+				target: "es2020",
+				external: ["node:http2"],
+				format: "esm",
+				splitting: true,
+				outdir: join(dir, "dist"),
+				metafile: true,
+				logLevel: "silent",
+				tsconfig: join(pkgRoot, "tsconfig.json"),
+			});
+
+			const outputs = result.metafile.outputs;
+			const entryOutput = Object.keys(outputs).find((path) =>
+				path.endsWith("/entry.js"),
+			);
+			expect(entryOutput).toBeDefined();
+
+			const initialOutputs = new Set<string>();
+			const visitInitialOutput = (path: string) => {
+				if (initialOutputs.has(path)) return;
+				initialOutputs.add(path);
+				for (const imported of outputs[path]?.imports ?? []) {
+					if (imported.kind === "import-statement" && outputs[imported.path]) {
+						visitInitialOutput(imported.path);
+					}
+				}
+			};
+			visitInitialOutput(entryOutput!);
+
+			const isProtoInput = (path: string) =>
+				path.includes("@protobuf-ts/runtime") ||
+				path.includes("generated/proto/s2.ts") ||
+				path.includes("stream/transport/proto.ts");
+			const initialProtoInputs = [...initialOutputs].flatMap((path) =>
+				Object.keys(outputs[path]?.inputs ?? {}).filter(isProtoInput),
+			);
+			const lazyProtoInputs = Object.entries(outputs)
+				.filter(([path]) => !initialOutputs.has(path))
+				.flatMap(([, output]) =>
+					Object.keys(output.inputs).filter(isProtoInput),
+				);
+
+			expect(initialProtoInputs).toEqual([]);
+			expect(lazyProtoInputs.length).toBeGreaterThan(0);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/streamstore/src/tests/lazyProto.test.ts
+++ b/packages/streamstore/src/tests/lazyProto.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "../generated/client/index.js";
+import { streamAppend } from "../lib/stream/transport/fetch/shared.js";
+import type { AppendInput, AppendRecord } from "../types.js";
+
+const mocks = vi.hoisted(() => ({
+	append: vi.fn(),
+	protoLoads: 0,
+}));
+
+vi.mock("../generated/index.js", () => ({
+	append: mocks.append,
+	read: vi.fn(),
+}));
+
+vi.mock("../lib/stream/transport/proto.js", () => {
+	mocks.protoLoads += 1;
+	return {
+		decodeProtoAppendAck: vi.fn(() => ({})),
+		decodeProtoReadBatch: vi.fn(),
+		encodeProtoAppendInput: vi.fn(() => new Uint8Array()),
+		protoAppendAckToJson: vi.fn(() => ({
+			start: { seqNum: 0, timestamp: new Date(0) },
+			end: { seqNum: 1, timestamp: new Date(0) },
+			tail: { seqNum: 1, timestamp: new Date(0) },
+		})),
+	};
+});
+
+const client = {} as Client;
+
+const input = (record: AppendRecord): AppendInput => ({
+	records: [record],
+	meteredBytes: record.meteredBytes,
+});
+
+describe("lazy protobuf codec", () => {
+	it("loads protobuf only when a binary operation needs it", async () => {
+		mocks.append.mockResolvedValueOnce({
+			data: {
+				start: { seq_num: 0, timestamp: 0 },
+				end: { seq_num: 1, timestamp: 0 },
+				tail: { seq_num: 1, timestamp: 0 },
+			},
+			response: { ok: true },
+		});
+
+		expect(mocks.protoLoads).toBe(0);
+		await streamAppend(
+			"test-stream",
+			client,
+			input({ body: "text", meteredBytes: 12 }),
+		);
+		expect(mocks.protoLoads).toBe(0);
+
+		mocks.append.mockResolvedValueOnce({
+			data: new ArrayBuffer(0),
+			response: { ok: true },
+		});
+
+		await streamAppend(
+			"test-stream",
+			client,
+			input({ body: new Uint8Array([1]), meteredBytes: 9 }),
+		);
+		expect(mocks.protoLoads).toBe(1);
+	});
+});

--- a/packages/streamstore/src/tests/lazyProtoError.test.ts
+++ b/packages/streamstore/src/tests/lazyProtoError.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { S2Error } from "../error.js";
+import type { Client } from "../generated/client/index.js";
+import { streamAppend } from "../lib/stream/transport/fetch/shared.js";
+import type { AppendInput } from "../types.js";
+
+const append = vi.hoisted(() => vi.fn());
+
+vi.mock("../generated/index.js", () => ({
+	append,
+	read: vi.fn(),
+}));
+
+vi.mock("../lib/stream/transport/proto.js", () => {
+	throw new TypeError("Failed to fetch");
+});
+
+describe("lazy protobuf codec errors", () => {
+	it("normalizes module-loading failures", async () => {
+		const input: AppendInput = {
+			records: [{ body: new Uint8Array([1]), meteredBytes: 9 }],
+			meteredBytes: 9,
+		};
+
+		const error = await streamAppend("test-stream", {} as Client, input).catch(
+			(caught) => caught,
+		);
+
+		expect(error).toBeInstanceOf(S2Error);
+		expect(append).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- dynamically import the protobuf codec only when Fetch reads or appends binary records
- keep management and JSON/string-mode usage from initializing the generated protobuf schema and runtime
- add regression coverage for lazy module evaluation and for the protobuf-free initial bundle graph
- add a patch changeset

## Measured impact

Using the same unminified esbuild entry (`import { S2 } ...`) with `platform: "node"`, ESM, and code splitting:

| | Before | After |
| --- | ---: | ---: |
| Initial static graph | 328,505 B | 188,399 B |
| Protobuf inputs in initial graph | 138,231 B | 0 B |
| Total output | 369,827 B | 370,613 B |

That removes 140,106 bytes (42.6%) from the initial graph. Total output remains effectively unchanged, as expected: code splitting defers the protobuf chunk rather than removing the binary feature. For single-file bundles, the dynamic import still defers schema/runtime evaluation until the first binary operation.

## Verification

- `bun run check`
- `bun run test` (571 passed, 294 credentialed E2E tests skipped)

Fixes #334
