### PR TITLE
Sign Changesets release commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           version: bun run version-with-docs
           publish: bun run release
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- create Changesets release commits through the GitHub API
- ensure release PR commits receive GitHub verified signatures
- unblock release PRs under the signed-commit ruleset

## Validation

- `git diff --check`
- workflow YAML parsed successfully