### PR TITLE
feat(streamstore): act on s2s reconnect advice

### DIFF
--- a/.changeset/reconnect-advice.md
+++ b/.changeset/reconnect-advice.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Act on s2s reconnect advice: sessions move to a fresh connection when a server starts draining, and the pooled connection the advice arrived on is dropped so no new stream reuses it.

--- a/.changeset/reconnect-advice.md
+++ b/.changeset/reconnect-advice.md
@@ -2,4 +2,4 @@
 "@s2-dev/streamstore": patch
 ---
 
-Act on s2s reconnect advice once per minute, keep terminal `server_draining` reconnects outside the ordinary retry budget, and drop draining connections from the pool.
+Act on s2s reconnect advice once per minute, keep terminal `server_draining` reconnects outside the ordinary retry budget, and drop draining connections from the pool. Read sessions now anchor a timestamp or tail-relative start to the tail of an empty batch, so a reconnect resumes from the caught-up position instead of re-evaluating the original start against a newer tail.

--- a/.changeset/reconnect-advice.md
+++ b/.changeset/reconnect-advice.md
@@ -2,4 +2,4 @@
 "@s2-dev/streamstore": patch
 ---
 
-Act on s2s reconnect advice: sessions move to a fresh connection when a server starts draining, and the pooled connection the advice arrived on is dropped so no new stream reuses it.
+Act on s2s reconnect advice once per minute, keep terminal `server_draining` reconnects outside the ordinary retry budget, and drop draining connections from the pool.

--- a/packages/streamstore/src/error.ts
+++ b/packages/streamstore/src/error.ts
@@ -285,7 +285,8 @@ export class S2Error extends Error {
 		if (this.origin === "server") {
 			return (
 				(this.status === 429 && this.code === "rate_limited") ||
-				(this.status === 502 && this.code === "hot_server")
+				(this.status === 502 && this.code === "hot_server") ||
+				(this.status === 503 && this.code === RECONNECT_ADVISED_CODE)
 			);
 		}
 		if (this.origin === "sdk") {
@@ -331,6 +332,25 @@ export function abortedError(message: string = "Request cancelled"): S2Error {
 		code: "ABORTED",
 		status: 499,
 		origin: "sdk",
+	});
+}
+
+/** Error code for a session interrupted by server reconnect advice. */
+export const RECONNECT_ADVISED_CODE = "reconnect_advised";
+
+/**
+ * Helper: construct a reconnect-advised error (503, retryable).
+ *
+ * Raised when a draining server flags session frames with reconnect advice.
+ * The session ended cleanly at a frame boundary, so retrying on a fresh
+ * connection cannot duplicate a mutation.
+ */
+export function reconnectAdvisedError(): S2Error {
+	return new S2Error({
+		message: "Server advised the session to reconnect",
+		code: RECONNECT_ADVISED_CODE,
+		status: 503,
+		origin: "server",
 	});
 }
 

--- a/packages/streamstore/src/error.ts
+++ b/packages/streamstore/src/error.ts
@@ -338,6 +338,10 @@ export function abortedError(message: string = "Request cancelled"): S2Error {
 /** Error code for a session interrupted by server reconnect advice. */
 export const RECONNECT_ADVISED_CODE = "reconnect_advised";
 
+export function isServerDraining(error: S2Error): boolean {
+	return error.status === 503 && error.code === "server_draining";
+}
+
 /**
  * Helper: construct a reconnect-advised error (503, retryable).
  *

--- a/packages/streamstore/src/error.ts
+++ b/packages/streamstore/src/error.ts
@@ -277,16 +277,21 @@ export class S2Error extends Error {
 	/**
 	 * Returns true if the error guarantees that no mutation occurred.
 	 *
-	 * Certain server errors (`rate_limited`, `hot_server`) and pre-connection
-	 * client errors (`ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`) are safe to
-	 * retry since they guarantee no side effects.
+	 * Certain server errors (`rate_limited`, `hot_server`, `server_draining`)
+	 * and pre-connection client errors (`ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`)
+	 * are safe to retry since they guarantee no side effects.
+	 *
+	 * A draining server acknowledges every input it accepted before ending the
+	 * session with `server_draining`, so anything still unacknowledged was never
+	 * registered and can be resubmitted.
 	 */
 	hasNoSideEffects(): boolean {
 		if (this.origin === "server") {
 			return (
 				(this.status === 429 && this.code === "rate_limited") ||
 				(this.status === 502 && this.code === "hot_server") ||
-				(this.status === 503 && this.code === RECONNECT_ADVISED_CODE)
+				(this.status === 503 && this.code === RECONNECT_ADVISED_CODE) ||
+				isServerDraining(this)
 			);
 		}
 		if (this.origin === "sdk") {

--- a/packages/streamstore/src/lib/reconnect.ts
+++ b/packages/streamstore/src/lib/reconnect.ts
@@ -1,0 +1,40 @@
+/** Max consecutive advised reconnects before delaying the next one. */
+const MAX_IMMEDIATE_ADVISED_RECONNECTS = 3;
+
+/** Delay applied past `MAX_IMMEDIATE_ADVISED_RECONNECTS`. */
+const ADVISED_RECONNECT_DELAY_MS = 100;
+
+/** If no reconnect advice arrives for this long, the consecutive count resets. */
+const ADVISED_RECONNECT_IDLE_MS = 10_000;
+
+/**
+ * Counts consecutive reconnects driven by server advice.
+ *
+ * A draining server keeps serving the session, so progress cannot tell a storm
+ * from an ordinary handover; how rapidly advice repeats can. Poisoning stops a
+ * pooled connection from being handed out again, but a fresh connection can
+ * still land back on the draining server while it leaves the load balancer's
+ * rotation, so the loop is paced rather than left to run at connect speed.
+ */
+export class AdvisedReconnects {
+	private count = 0;
+	private lastMonotonicMs: number | undefined;
+
+	/**
+	 * Register an advised reconnect and report how long to wait before opening
+	 * the next connection.
+	 */
+	record(nowMonotonicMs: number = performance.now()): number {
+		if (
+			this.lastMonotonicMs !== undefined &&
+			nowMonotonicMs - this.lastMonotonicMs > ADVISED_RECONNECT_IDLE_MS
+		) {
+			this.count = 0;
+		}
+		this.lastMonotonicMs = nowMonotonicMs;
+		this.count++;
+		return this.count > MAX_IMMEDIATE_ADVISED_RECONNECTS
+			? ADVISED_RECONNECT_DELAY_MS
+			: 0;
+	}
+}

--- a/packages/streamstore/src/lib/reconnect.ts
+++ b/packages/streamstore/src/lib/reconnect.ts
@@ -1,40 +1,35 @@
-/** Max consecutive advised reconnects before delaying the next one. */
-const MAX_IMMEDIATE_ADVISED_RECONNECTS = 3;
+/** Advised reconnects to attempt before staying on. */
+const MAX_ADVISED_RECONNECTS = 1;
 
-/** Delay applied past `MAX_IMMEDIATE_ADVISED_RECONNECTS`. */
-const ADVISED_RECONNECT_DELAY_MS = 100;
-
-/** If no reconnect advice arrives for this long, the consecutive count resets. */
-const ADVISED_RECONNECT_IDLE_MS = 10_000;
+/** Gap after which the attempt count resets. */
+const ADVISED_RECONNECT_IDLE_MS = 60_000;
 
 /**
- * Counts consecutive reconnects driven by server advice.
- *
- * A draining server keeps serving the session, so progress cannot tell a storm
- * from an ordinary handover; how rapidly advice repeats can. Poisoning stops a
- * pooled connection from being handed out again, but a fresh connection can
- * still land back on the draining server while it leaves the load balancer's
- * rotation, so the loop is paced rather than left to run at connect speed.
+ * Tracks advised reconnects attempted lately.
  */
 export class AdvisedReconnects {
 	private count = 0;
 	private lastMonotonicMs: number | undefined;
 
-	/**
-	 * Register an advised reconnect and report how long to wait before opening
-	 * the next connection.
-	 */
-	record(nowMonotonicMs: number = performance.now()): number {
-		if (
-			this.lastMonotonicMs !== undefined &&
-			nowMonotonicMs - this.lastMonotonicMs > ADVISED_RECONNECT_IDLE_MS
-		) {
+	record(nowMonotonicMs: number = performance.now()): void {
+		if (!this.isRecent(nowMonotonicMs)) {
 			this.count = 0;
 		}
 		this.lastMonotonicMs = nowMonotonicMs;
 		this.count++;
-		return this.count > MAX_IMMEDIATE_ADVISED_RECONNECTS
-			? ADVISED_RECONNECT_DELAY_MS
-			: 0;
+	}
+
+	/** Whether to act on advice, or stay until the server ends the connection. */
+	shouldReconnect(nowMonotonicMs: number = performance.now()): boolean {
+		return (
+			!this.isRecent(nowMonotonicMs) || this.count < MAX_ADVISED_RECONNECTS
+		);
+	}
+
+	private isRecent(nowMonotonicMs: number): boolean {
+		return (
+			this.lastMonotonicMs !== undefined &&
+			nowMonotonicMs - this.lastMonotonicMs <= ADVISED_RECONNECT_IDLE_MS
+		);
 	}
 }

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -3,6 +3,7 @@ import type { RetryConfig } from "../common.js";
 import {
 	abortedError,
 	invariantViolation,
+	isServerDraining,
 	RECONNECT_ADVISED_CODE,
 	S2Error,
 	s2Error,
@@ -12,7 +13,6 @@ import type * as API from "../generated/index.js";
 import * as Types from "../types.js";
 import { isCommandRecord, meteredBytes } from "../utils.js";
 import { FifoQueue } from "./queue.js";
-import { AdvisedReconnects } from "./reconnect.js";
 import type { AppendResult, CloseResult } from "./result.js";
 import { err, errClose, ok, okClose } from "./result.js";
 import {
@@ -281,21 +281,26 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			} catch (err) {
 				const error = s2Error(err);
 				lastError = error;
+				const draining = isServerDraining(error);
 
 				const effectiveMax = Math.max(1, retryConfig.maxAttempts);
-				if (isRetryable(error) && attempt < effectiveMax - 1) {
-					const delay = calculateDelay(
-						attempt,
-						retryConfig.minBaseDelayMillis,
-						retryConfig.maxBaseDelayMillis,
-					);
+				if (isRetryable(error) && (draining || attempt < effectiveMax - 1)) {
+					const delay = draining
+						? 0
+						: calculateDelay(
+								attempt,
+								retryConfig.minBaseDelayMillis,
+								retryConfig.maxBaseDelayMillis,
+							);
 					debugRead(
 						"connection error in create, will retry after %dms, status=%s",
 						delay,
 						error.status,
 					);
 					await sleep(delay);
-					attempt++;
+					if (!draining) {
+						attempt++;
+					}
 					continue;
 				}
 
@@ -381,7 +386,6 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			const baselineBytes = args?.bytes;
 			const baselineWait = args?.wait;
 			let attempt = 0;
-			const advisedReconnects = new AdvisedReconnects();
 
 			while (true) {
 				if (cancelled) {
@@ -401,14 +405,20 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 						}
 					} catch (err) {
 						const error = s2Error(err);
+						const draining = isServerDraining(error);
 
 						const effectiveMax = Math.max(1, retryConfig.maxAttempts);
-						if (isRetryable(error) && attempt < effectiveMax - 1) {
-							const delay = calculateDelay(
-								attempt,
-								retryConfig.minBaseDelayMillis,
-								retryConfig.maxBaseDelayMillis,
-							);
+						if (
+							isRetryable(error) &&
+							(draining || attempt < effectiveMax - 1)
+						) {
+							const delay = draining
+								? 0
+								: calculateDelay(
+										attempt,
+										retryConfig.minBaseDelayMillis,
+										retryConfig.maxBaseDelayMillis,
+									);
 							debugRead(
 								"connection error, will retry after %dms, status=%s",
 								delay,
@@ -418,7 +428,9 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 							if (cancelled) {
 								return;
 							}
-							attempt++;
+							if (!draining) {
+								attempt++;
+							}
 							continue;
 						}
 
@@ -474,12 +486,14 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 						currentReader = undefined;
 						const error = result.error;
 
-						// Reconnect advice is the server draining, not a failure: it
-						// does not consume retry attempts, so a session that keeps
-						// landing on draining servers is never aborted for it.
-						const advised = error.code === RECONNECT_ADVISED_CODE;
+						// Planned drain handoffs do not consume retry attempts.
+						const draining =
+							error.code === RECONNECT_ADVISED_CODE || isServerDraining(error);
 						const effectiveMax = Math.max(1, retryConfig.maxAttempts);
-						if (isRetryable(error) && (advised || attempt < effectiveMax - 1)) {
+						if (
+							isRetryable(error) &&
+							(draining || attempt < effectiveMax - 1)
+						) {
 							const retryFromSeqNum =
 								this._nextReadPosition?.seq_num ?? nextArgs.seq_num;
 							if (this._nextReadPosition) {
@@ -488,10 +502,8 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 								delete nextArgs.timestamp;
 								delete nextArgs.tail_offset;
 							}
-							// A drain keeps serving batches, so advice is paced on how
-							// quickly it repeats rather than on progress.
-							const delay = advised
-								? advisedReconnects.record()
+							const delay = draining
+								? 0
 								: calculateDelay(
 										attempt,
 										retryConfig.minBaseDelayMillis,
@@ -505,7 +517,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 							}
 							// Avoid a useless reconnect for a read that was already
 							// satisfied when the advice arrived.
-							if (advised && (nextArgs.count === 0 || nextArgs.bytes === 0)) {
+							if (draining && (nextArgs.count === 0 || nextArgs.bytes === 0)) {
 								debugRead("read limits reached on server advice");
 								try {
 									await session.cancel?.("limits reached");
@@ -537,21 +549,29 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 
 							session = undefined;
 
-							debugRead(
-								"will retry after %dms, status=%s code=%s attempt=%d/%d next_seq_num=%s records_read=%d",
-								delay,
-								error.status,
-								error.code,
-								attempt + 1,
-								effectiveMax - 1,
-								retryFromSeqNum ?? "unknown",
-								this._recordsRead,
-							);
+							if (draining) {
+								debugRead(
+									"reconnecting read session while server drains, next_seq_num=%s records_read=%d",
+									retryFromSeqNum ?? "unknown",
+									this._recordsRead,
+								);
+							} else {
+								debugRead(
+									"will retry after %dms, status=%s code=%s attempt=%d/%d next_seq_num=%s records_read=%d",
+									delay,
+									error.status,
+									error.code,
+									attempt + 1,
+									effectiveMax - 1,
+									retryFromSeqNum ?? "unknown",
+									this._recordsRead,
+								);
+							}
 							await sleep(delay);
 							if (cancelled) {
 								return;
 							}
-							if (!advised) {
+							if (!draining) {
 								attempt++;
 							}
 							break;
@@ -802,7 +822,6 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 	private pendingBytes = 0;
 	private pendingBatches = 0;
 	private consecutiveFailures = 0;
-	private readonly advisedReconnects = new AdvisedReconnects();
 	private currentAttempt = 0;
 
 	private pumpPromise?: Promise<void>;
@@ -1435,7 +1454,11 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				// we can determine no mutation occurred. This is true if either:
 				// 1. The error itself guarantees no side effects (e.g. rate_limited, hot_server)
 				// 2. The transport reports no data was sent since the last dormant state
+				const draining =
+					error.code === RECONNECT_ADVISED_CODE || isServerDraining(error);
+
 				if (
+					!draining &&
 					this.retryConfig.appendRetryPolicy === "noSideEffects" &&
 					!error.hasNoSideEffects() &&
 					(this.session?.effectSignalled() ?? true)
@@ -1452,7 +1475,10 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				// are idempotent. Non-idempotent entries that were already
 				// sent may have been processed, and resubmitting would cause
 				// duplicates.
-				if (this.retryConfig.appendRetryPolicy === "noSideEffects") {
+				if (
+					!draining &&
+					this.retryConfig.appendRetryPolicy === "noSideEffects"
+				) {
 					const hasNonIdempotentSent = this.inflight.some(
 						(entry, index) =>
 							index > 0 &&
@@ -1469,15 +1495,11 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 					}
 				}
 
-				// Reconnect advice is the server draining, not a failure: it does
-				// not consume retry attempts, so a session that keeps landing on
-				// draining servers is never aborted for it.
-				const advised = error.code === RECONNECT_ADVISED_CODE;
-
+				// Planned drain handoffs do not consume retry attempts.
 				// Check max attempts (total attempts include initial; retries = max - 1)
 				const effectiveMax = Math.max(1, this.retryConfig.maxAttempts);
 				const allowedRetries = effectiveMax - 1;
-				if (!advised && this.currentAttempt >= allowedRetries) {
+				if (!draining && this.currentAttempt >= allowedRetries) {
 					debugSession(
 						"[%s] max attempts reached (%d), aborting",
 						this.streamName,
@@ -1493,15 +1515,10 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				}
 
 				// Perform recovery
-				let advisedBackoffMillis: number | undefined;
-				if (advised) {
-					// A drain keeps acknowledging work, so pace on how quickly
-					// advice repeats rather than on progress.
-					advisedBackoffMillis = this.advisedReconnects.record();
+				if (draining) {
 					debugSession(
-						"[%s] reconnecting append session on server advice, delay=%dms",
+						"[%s] reconnecting append session while server drains",
 						this.streamName,
-						advisedBackoffMillis,
 					);
 				} else {
 					this.consecutiveFailures++;
@@ -1515,7 +1532,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 					);
 				}
 
-				await this.recover(advisedBackoffMillis);
+				await this.recover(draining ? 0 : undefined);
 			}
 		}
 	}
@@ -1562,7 +1579,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 	private async recover(backoffMillis?: number): Promise<void> {
 		debugSession("[%s] starting recovery", this.streamName);
 
-		// Calculate backoff delay, unless the caller paced this reconnect.
+		// Calculate backoff unless the caller supplied a delay.
 		const delay =
 			backoffMillis ??
 			calculateDelay(

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -3,6 +3,7 @@ import type { RetryConfig } from "../common.js";
 import {
 	abortedError,
 	invariantViolation,
+	RECONNECT_ADVISED_CODE,
 	S2Error,
 	s2Error,
 	withS2Error,
@@ -11,6 +12,7 @@ import type * as API from "../generated/index.js";
 import * as Types from "../types.js";
 import { isCommandRecord, meteredBytes } from "../utils.js";
 import { FifoQueue } from "./queue.js";
+import { AdvisedReconnects } from "./reconnect.js";
 import type { AppendResult, CloseResult } from "./result.js";
 import { err, errClose, ok, okClose } from "./result.js";
 import {
@@ -379,6 +381,7 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 			const baselineBytes = args?.bytes;
 			const baselineWait = args?.wait;
 			let attempt = 0;
+			const advisedReconnects = new AdvisedReconnects();
 
 			while (true) {
 				if (cancelled) {
@@ -471,8 +474,12 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 						currentReader = undefined;
 						const error = result.error;
 
+						// Reconnect advice is the server draining, not a failure: it
+						// does not consume retry attempts, so a session that keeps
+						// landing on draining servers is never aborted for it.
+						const advised = error.code === RECONNECT_ADVISED_CODE;
 						const effectiveMax = Math.max(1, retryConfig.maxAttempts);
-						if (isRetryable(error) && attempt < effectiveMax - 1) {
+						if (isRetryable(error) && (advised || attempt < effectiveMax - 1)) {
 							const retryFromSeqNum =
 								this._nextReadPosition?.seq_num ?? nextArgs.seq_num;
 							if (this._nextReadPosition) {
@@ -481,16 +488,33 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 								delete nextArgs.timestamp;
 								delete nextArgs.tail_offset;
 							}
-							const delay = calculateDelay(
-								attempt,
-								retryConfig.minBaseDelayMillis,
-								retryConfig.maxBaseDelayMillis,
-							);
+							// A drain keeps serving batches, so advice is paced on how
+							// quickly it repeats rather than on progress.
+							const delay = advised
+								? advisedReconnects.record()
+								: calculateDelay(
+										attempt,
+										retryConfig.minBaseDelayMillis,
+										retryConfig.maxBaseDelayMillis,
+									);
 							if (baselineCount !== undefined) {
 								nextArgs.count = Math.max(0, baselineCount - this._recordsRead);
 							}
 							if (baselineBytes !== undefined) {
 								nextArgs.bytes = Math.max(0, baselineBytes - this._bytesRead);
+							}
+							// Avoid a useless reconnect for a read that was already
+							// satisfied when the advice arrived.
+							if (advised && (nextArgs.count === 0 || nextArgs.bytes === 0)) {
+								debugRead("read limits reached on server advice");
+								try {
+									await session.cancel?.("limits reached");
+								} catch {}
+								session = undefined;
+								caughtUpTracker.end();
+								pumpDone = true;
+								wake();
+								return;
 							}
 							// After observing a tail, subtract elapsed time and retry delay.
 							if (baselineWait !== undefined) {
@@ -527,7 +551,9 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 							if (cancelled) {
 								return;
 							}
-							attempt++;
+							if (!advised) {
+								attempt++;
+							}
 							break;
 						}
 
@@ -776,6 +802,7 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 	private pendingBytes = 0;
 	private pendingBatches = 0;
 	private consecutiveFailures = 0;
+	private readonly advisedReconnects = new AdvisedReconnects();
 	private currentAttempt = 0;
 
 	private pumpPromise?: Promise<void>;
@@ -1442,10 +1469,15 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 					}
 				}
 
+				// Reconnect advice is the server draining, not a failure: it does
+				// not consume retry attempts, so a session that keeps landing on
+				// draining servers is never aborted for it.
+				const advised = error.code === RECONNECT_ADVISED_CODE;
+
 				// Check max attempts (total attempts include initial; retries = max - 1)
 				const effectiveMax = Math.max(1, this.retryConfig.maxAttempts);
 				const allowedRetries = effectiveMax - 1;
-				if (this.currentAttempt >= allowedRetries) {
+				if (!advised && this.currentAttempt >= allowedRetries) {
 					debugSession(
 						"[%s] max attempts reached (%d), aborting",
 						this.streamName,
@@ -1461,17 +1493,29 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				}
 
 				// Perform recovery
-				this.consecutiveFailures++;
-				this.currentAttempt++;
+				let advisedBackoffMillis: number | undefined;
+				if (advised) {
+					// A drain keeps acknowledging work, so pace on how quickly
+					// advice repeats rather than on progress.
+					advisedBackoffMillis = this.advisedReconnects.record();
+					debugSession(
+						"[%s] reconnecting append session on server advice, delay=%dms",
+						this.streamName,
+						advisedBackoffMillis,
+					);
+				} else {
+					this.consecutiveFailures++;
+					this.currentAttempt++;
 
-				debugSession(
-					"[%s] performing recovery (retry %d/%d)",
-					this.streamName,
-					this.currentAttempt,
-					allowedRetries,
-				);
+					debugSession(
+						"[%s] performing recovery (retry %d/%d)",
+						this.streamName,
+						this.currentAttempt,
+						allowedRetries,
+					);
+				}
 
-				await this.recover();
+				await this.recover(advisedBackoffMillis);
 			}
 		}
 	}
@@ -1515,15 +1559,17 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 	/**
 	 * Recover from transient error: recreate session and resubmit all inflight entries.
 	 */
-	private async recover(): Promise<void> {
+	private async recover(backoffMillis?: number): Promise<void> {
 		debugSession("[%s] starting recovery", this.streamName);
 
-		// Calculate backoff delay
-		const delay = calculateDelay(
-			this.consecutiveFailures - 1,
-			this.retryConfig.minBaseDelayMillis,
-			this.retryConfig.maxBaseDelayMillis,
-		);
+		// Calculate backoff delay, unless the caller paced this reconnect.
+		const delay =
+			backoffMillis ??
+			calculateDelay(
+				this.consecutiveFailures - 1,
+				this.retryConfig.minBaseDelayMillis,
+				this.retryConfig.maxBaseDelayMillis,
+			);
 		debugSession("[%s] backing off for %dms", this.streamName, delay);
 		await sleep(delay);
 

--- a/packages/streamstore/src/lib/retry.ts
+++ b/packages/streamstore/src/lib/retry.ts
@@ -589,6 +589,16 @@ export class RetryReadSession<Format extends "string" | "bytes" = "string">
 						lastSeqNum: lastRecord?.seq_num,
 						tail: tail ? toSDKStreamPosition(tail) : undefined,
 					});
+					// An empty batch with a tail still resolves a timestamp or
+					// tail-relative start. Anchoring here keeps a reconnect from
+					// evaluating the original start against a newer tail and
+					// skipping or re-reading records appended in between.
+					if (records.length === 0 && tail) {
+						this._nextReadPosition = {
+							seq_num: tail.seq_num,
+							timestamp: tail.timestamp,
+						};
+					}
 					const visibleRecords: Types.ReadRecord<Format>[] = [];
 					for (const record of records) {
 						this._nextReadPosition = {
@@ -1454,11 +1464,17 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				// we can determine no mutation occurred. This is true if either:
 				// 1. The error itself guarantees no side effects (e.g. rate_limited, hot_server)
 				// 2. The transport reports no data was sent since the last dormant state
+				// Planned drain handoffs. Both errors guarantee no side effects: an
+				// advised session refuses new input without writing it, and a
+				// draining server acknowledges everything it accepted before ending
+				// the session, so anything still unacknowledged was never
+				// registered. If the server's drain window lapses instead, the
+				// connection drops without `server_draining` and the ordinary
+				// ambiguous-disconnect handling below applies.
 				const draining =
 					error.code === RECONNECT_ADVISED_CODE || isServerDraining(error);
 
 				if (
-					!draining &&
 					this.retryConfig.appendRetryPolicy === "noSideEffects" &&
 					!error.hasNoSideEffects() &&
 					(this.session?.effectSignalled() ?? true)
@@ -1474,7 +1490,9 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 				// Under noSideEffects, also check that all inflight entries
 				// are idempotent. Non-idempotent entries that were already
 				// sent may have been processed, and resubmitting would cause
-				// duplicates.
+				// duplicates. A drain handoff is exempt: the server acknowledged
+				// every accepted input before ending the session, so the
+				// unacknowledged remainder was never processed.
 				if (
 					!draining &&
 					this.retryConfig.appendRetryPolicy === "noSideEffects"
@@ -1495,7 +1513,11 @@ export class RetryAppendSession implements AsyncDisposable, AppendSessionType {
 					}
 				}
 
-				// Planned drain handoffs do not consume retry attempts.
+				// Planned drain handoffs do not consume retry attempts. Repeated
+				// handoffs stay bounded because the draining connection has been
+				// dropped from the pool and the server refuses new connections once
+				// it drains, so a fresh dial either lands elsewhere or fails with an
+				// ordinary, budgeted error.
 				// Check max attempts (total attempts include initial; retries = max - 1)
 				const effectiveMax = Math.max(1, this.retryConfig.maxAttempts);
 				const allowedRetries = effectiveMax - 1;

--- a/packages/streamstore/src/lib/stream/transport/s2s/framing.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/framing.ts
@@ -3,10 +3,12 @@
  *
  * Message format:
  * - 3 bytes: Length prefix (total message length including flag byte, big-endian)
- * - 1 byte: Flag byte [T][CC][RRRRR]
+ * - 1 byte: Flag byte [T][CC][A][RRRR]
  *   - T (bit 7): Terminal flag (1 = stream ends after this message)
  *   - CC (bits 6-5): Compression (00=none, 01=zstd, 10=gzip)
- *   - RRRRR (bits 4-0): Reserved
+ *   - A (bit 4): Reconnect advised (regular frames only; the server is
+ *     draining and asks the session to move to a new connection)
+ *   - RRRR (bits 3-0): Reserved
  * - Variable: Body (protobuf message or JSON error for terminal frames)
  */
 
@@ -21,6 +23,8 @@ export const MAX_DECOMPRESSED_PAYLOAD_BYTES = MAX_FRAME_PAYLOAD_BYTES;
 export interface S2SFrame {
 	terminal: boolean;
 	compression: CompressionType;
+	/** Server is draining; the session should move to a new connection. */
+	reconnectAdvised: boolean;
 	body: Uint8Array;
 	statusCode?: number; // Only for terminal frames
 }
@@ -133,6 +137,7 @@ export class S2SFrameParser {
 		// Read flag byte
 		const flag = this.buffer[3]!;
 		const terminal = (flag & 0x80) !== 0;
+		const reconnectAdvised = !terminal && (flag & 0x10) !== 0;
 		const compressionBits = (flag & 0x60) >> 5;
 		let compression: CompressionType;
 		switch (compressionBits) {
@@ -168,6 +173,7 @@ export class S2SFrameParser {
 		return {
 			terminal,
 			compression,
+			reconnectAdvised,
 			body,
 			statusCode,
 		};

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -19,6 +19,7 @@ import {
 	makeAppendPreconditionError,
 	makeServerError,
 	RangeNotSatisfiableError,
+	reconnectAdvisedError,
 	S2Error,
 	s2Error,
 } from "../../../../error.js";
@@ -65,16 +66,14 @@ import {
 	frameMessage,
 	S2SFrameParser,
 } from "./framing.js";
-import { sharedConnectionPool } from "./pool.js";
+import { type PooledStream, sharedConnectionPool } from "./pool.js";
 
 const debug = createDebug("s2:s2s");
 
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
 /** Opens an HTTP/2 stream to the transport's endpoint. */
-type OpenH2Stream = (
-	headers: OutgoingHttpHeaders,
-) => Promise<ClientHttp2Stream>;
+type OpenH2Stream = (headers: OutgoingHttpHeaders) => Promise<PooledStream>;
 
 export class S2STransport implements SessionTransport {
 	private readonly transportConfig: TransportConfig;
@@ -340,7 +339,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					const path = `${url.pathname}/streams/${encodeURIComponent(streamName)}/records${queryString ? `?${queryString}` : ""}`;
 
 					const acceptEncoding = await acceptEncodingHeader(compression);
-					const stream = await openH2Stream({
+					const { stream, poison } = await openH2Stream({
 						":method": "GET",
 						":path": path,
 						":scheme": url.protocol.slice(0, -1),
@@ -516,6 +515,18 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 											ok: true,
 											batch: { records, ...(tail ? { tail } : {}) },
 										});
+
+										// Checked after delivery so the resume position already
+										// accounts for this batch. Poisoning here rather than on
+										// reconnect keeps the pool clean whatever the retry layer
+										// goes on to do.
+										if (frame.reconnectAdvised) {
+											debug("reconnect advised, ending read session");
+											poison();
+											safeError(reconnectAdvisedError());
+											stream.close();
+											return;
+										}
 									} catch (err) {
 										safeError(
 											new S2Error({
@@ -687,6 +698,10 @@ class S2SAppendSession implements TransportAppendSession {
 	private initPromise?: Promise<void>;
 	private _effectSignalled = false;
 	private abortHandler?: () => void;
+	// Set once the server flags an ack frame as reconnect-advised; new batches
+	// are rejected with a retryable error so the retry layer recreates the
+	// session on a fresh connection once pipelined acks drain.
+	private reconnectAdvised = false;
 
 	static async create(
 		baseUrl: string,
@@ -733,7 +748,7 @@ class S2SAppendSession implements TransportAppendSession {
 		const path = `${url.pathname}/streams/${encodeURIComponent(this.streamName)}/records`;
 
 		const acceptEncoding = await acceptEncodingHeader(this.compression);
-		const stream = await this.openH2Stream({
+		const { stream, poison } = await this.openH2Stream({
 			":method": "POST",
 			":path": path,
 			":scheme": url.protocol.slice(0, -1),
@@ -846,6 +861,14 @@ class S2SAppendSession implements TransportAppendSession {
 						}
 						stream.close();
 					} else {
+						// The first advice poisons the pooled connection immediately,
+						// so no new stream reuses a connection pinned to the draining
+						// server, whatever this session goes on to do.
+						if (frame.reconnectAdvised && !this.reconnectAdvised) {
+							debug("reconnect advised, draining append session");
+							this.reconnectAdvised = true;
+							poison();
+						}
 						// Parse AppendAck
 						try {
 							const ackBytes =
@@ -863,6 +886,11 @@ class S2SAppendSession implements TransportAppendSession {
 							// Reset effect signal when dormant (no pending acks)
 							if (this.pendingAcks.length === 0) {
 								this._effectSignalled = false;
+								// Everything submitted was acknowledged; half-close so the
+								// draining server can end the response cleanly.
+								if (this.reconnectAdvised && !stream.writableEnded) {
+									stream.end();
+								}
 							}
 						} catch (parseErr) {
 							queueMicrotask(() =>
@@ -920,6 +948,11 @@ class S2SAppendSession implements TransportAppendSession {
 	 * Pipelined: multiple sends can be in-flight; acks resolve FIFO.
 	 */
 	private async sendBatch(input: Types.AppendInput): Promise<AppendResult> {
+		if (this.reconnectAdvised) {
+			// Refuse the advised stream without writing, so the retry layer can
+			// resubmit on a fresh session with no risk of duplication.
+			return Promise.resolve(err(reconnectAdvisedError()));
+		}
 		if (!this.http2Stream || this.http2Stream.closed) {
 			return Promise.resolve(
 				err(new S2Error({ message: "HTTP/2 stream is not open", status: 502 })),

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -16,6 +16,7 @@ type ReadableStreamWithAsyncIterator<T> = ReadableStream<T> & {
 
 import type { S2RequestOptions } from "../../../../common.js";
 import {
+	isServerDraining,
 	makeAppendPreconditionError,
 	makeServerError,
 	RangeNotSatisfiableError,
@@ -29,6 +30,7 @@ import { fromAPIStreamPosition } from "../../../../internal/mappers.js";
 import type * as Types from "../../../../types.js";
 import { S2_ENCRYPTION_KEY_HEADER } from "../../../encryption.js";
 import { FifoQueue } from "../../../queue.js";
+import { AdvisedReconnects } from "../../../reconnect.js";
 import * as Redacted from "../../../redacted.js";
 import type { AppendResult, CloseResult } from "../../../result.js";
 import { err, errClose, ok, okClose } from "../../../result.js";
@@ -95,6 +97,7 @@ export class S2STransport implements SessionTransport {
 		requestOptions?: S2RequestOptions,
 	): Promise<AppendSession> {
 		await assertCompressionSupported(this.compression);
+		const advisedReconnects = new AdvisedReconnects();
 		return AppendSessionImpl.create(
 			(myOptions) => {
 				return S2SAppendSession.create(
@@ -105,6 +108,7 @@ export class S2STransport implements SessionTransport {
 					this.transportConfig.basinName,
 					this.transportConfig.encryptionKey,
 					this.compression,
+					advisedReconnects,
 					myOptions,
 					requestOptions,
 				);
@@ -121,6 +125,7 @@ export class S2STransport implements SessionTransport {
 		options?: S2RequestOptions,
 	): Promise<ReadSession<Format>> {
 		await assertCompressionSupported(this.compression);
+		const advisedReconnects = new AdvisedReconnects();
 		return ReadSessionImpl.create(
 			(myArgs) => {
 				return S2SReadSession.create(
@@ -133,6 +138,7 @@ export class S2STransport implements SessionTransport {
 					this.transportConfig.basinName,
 					this.transportConfig.encryptionKey,
 					this.compression,
+					advisedReconnects,
 				);
 			},
 			args,
@@ -203,6 +209,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		basinName?: string,
 		encryptionKey?: Redacted.Redacted<string>,
 		compression: CompressionType = "none",
+		advisedReconnects: AdvisedReconnects = new AdvisedReconnects(),
 	): Promise<S2SReadSession<Format>> {
 		const url = new URL(baseUrl);
 		return new S2SReadSession(
@@ -215,6 +222,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 			basinName,
 			encryptionKey,
 			compression,
+			advisedReconnects,
 		);
 	}
 
@@ -228,6 +236,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 		private basinName?: string,
 		private encryptionKey?: Redacted.Redacted<string>,
 		private compression: CompressionType = "none",
+		private advisedReconnects: AdvisedReconnects = new AdvisedReconnects(),
 	) {
 		const parser = new S2SFrameParser();
 		const textDecoder = new TextDecoder();
@@ -358,6 +367,14 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					});
 
 					http2Stream = stream;
+					let declinedAdvice = false;
+					const handleServerError = (error: S2Error) => {
+						if (isServerDraining(error)) {
+							poison();
+							this.advisedReconnects.record();
+						}
+						safeError(error);
+					};
 					if (controllerClosed) {
 						stream.close();
 						return;
@@ -419,7 +436,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 								}
 								try {
 									const errorJson = JSON.parse(errorText);
-									safeError(
+									handleServerError(
 										new S2Error({
 											message: errorJson.message ?? "Unknown error",
 											code: errorJson.code,
@@ -428,7 +445,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 										}),
 									);
 								} catch {
-									safeError(
+									handleServerError(
 										new S2Error({
 											message: errorText || "Unknown error",
 											status,
@@ -462,7 +479,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 													}),
 												);
 											} else {
-												safeError(
+												handleServerError(
 													makeServerError(
 														{ status, statusText: undefined },
 														errorJson,
@@ -470,7 +487,7 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 												);
 											}
 										} catch {
-											safeError(
+											handleServerError(
 												makeServerError(
 													{
 														status: frame.statusCode ?? 500,
@@ -520,12 +537,16 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 										// accounts for this batch. Poisoning here rather than on
 										// reconnect keeps the pool clean whatever the retry layer
 										// goes on to do.
-										if (frame.reconnectAdvised) {
-											debug("reconnect advised, ending read session");
+										if (frame.reconnectAdvised && !declinedAdvice) {
 											poison();
-											safeError(reconnectAdvisedError());
-											stream.close();
-											return;
+											if (this.advisedReconnects.shouldReconnect()) {
+												this.advisedReconnects.record();
+												debug("reconnect advised, ending read session");
+												safeError(reconnectAdvisedError());
+												stream.close();
+												return;
+											}
+											declinedAdvice = true;
 										}
 									} catch (err) {
 										safeError(
@@ -698,10 +719,9 @@ class S2SAppendSession implements TransportAppendSession {
 	private initPromise?: Promise<void>;
 	private _effectSignalled = false;
 	private abortHandler?: () => void;
-	// Set once the server flags an ack frame as reconnect-advised; new batches
-	// are rejected with a retryable error so the retry layer recreates the
-	// session on a fresh connection once pipelined acks drain.
 	private reconnectAdvised = false;
+	private reconnectDeclined = false;
+	private terminalError?: S2Error;
 
 	static async create(
 		baseUrl: string,
@@ -711,6 +731,7 @@ class S2SAppendSession implements TransportAppendSession {
 		basinName: string | undefined,
 		encryptionKey: Redacted.Redacted<string> | undefined,
 		compression: CompressionType,
+		advisedReconnects: AdvisedReconnects,
 		sessionOptions?: AppendSessionOptions,
 		requestOptions?: S2RequestOptions,
 	): Promise<S2SAppendSession> {
@@ -722,6 +743,7 @@ class S2SAppendSession implements TransportAppendSession {
 			basinName,
 			encryptionKey,
 			compression,
+			advisedReconnects,
 			sessionOptions,
 			requestOptions,
 		);
@@ -735,6 +757,7 @@ class S2SAppendSession implements TransportAppendSession {
 		private basinName: string | undefined,
 		private encryptionKey: Redacted.Redacted<string> | undefined,
 		private compression: CompressionType,
+		private advisedReconnects: AdvisedReconnects,
 		sessionOptions?: AppendSessionOptions,
 		private options?: S2RequestOptions,
 	) {
@@ -783,14 +806,25 @@ class S2SAppendSession implements TransportAppendSession {
 		let pendingChunks: Buffer[] | undefined;
 
 		const safeError = (error: unknown) => {
+			const normalized = s2Error(error);
+			this.terminalError = normalized;
 			// Resolve all pending acks with error result
 			for (const pending of this.pendingAcks) {
-				pending.resolve(err(s2Error(error)));
+				pending.resolve(err(normalized));
 			}
 			this.pendingAcks.clear();
 			// Note: do NOT reset _effectSignalled here. Data may have been
 			// written to the wire before the error occurred, so the flag
 			// must stay true until the session is recreated.
+		};
+		const handleServerError = (error: S2Error) => {
+			if (isServerDraining(error)) {
+				poison();
+				if (!this.reconnectAdvised || this.reconnectDeclined) {
+					this.advisedReconnects.record();
+				}
+			}
+			safeError(error);
 		};
 
 		// Capture HTTP response status
@@ -813,7 +847,7 @@ class S2SAppendSession implements TransportAppendSession {
 					const errorText = textDecoder.decode(chunk);
 					try {
 						const errorJson = JSON.parse(errorText);
-						safeError(
+						handleServerError(
 							new S2Error({
 								message: errorJson.message ?? "Unknown error",
 								code: errorJson.code,
@@ -822,7 +856,7 @@ class S2SAppendSession implements TransportAppendSession {
 							}),
 						);
 					} catch {
-						safeError(
+						handleServerError(
 							new S2Error({
 								message: errorText || "Unknown error",
 								status: responseCode,
@@ -850,13 +884,13 @@ class S2SAppendSession implements TransportAppendSession {
 												{ status, statusText: undefined },
 												errorJson,
 											);
-								queueMicrotask(() => safeError(err));
+								queueMicrotask(() => handleServerError(err));
 							} catch {
 								const err = makeServerError(
 									{ status, statusText: undefined },
 									errorText,
 								);
-								queueMicrotask(() => safeError(err));
+								queueMicrotask(() => handleServerError(err));
 							}
 						}
 						stream.close();
@@ -865,9 +899,14 @@ class S2SAppendSession implements TransportAppendSession {
 						// so no new stream reuses a connection pinned to the draining
 						// server, whatever this session goes on to do.
 						if (frame.reconnectAdvised && !this.reconnectAdvised) {
-							debug("reconnect advised, draining append session");
 							this.reconnectAdvised = true;
 							poison();
+							if (this.advisedReconnects.shouldReconnect()) {
+								this.advisedReconnects.record();
+								debug("reconnect advised, draining append session");
+							} else {
+								this.reconnectDeclined = true;
+							}
 						}
 						// Parse AppendAck
 						try {
@@ -888,7 +927,11 @@ class S2SAppendSession implements TransportAppendSession {
 								this._effectSignalled = false;
 								// Everything submitted was acknowledged; half-close so the
 								// draining server can end the response cleanly.
-								if (this.reconnectAdvised && !stream.writableEnded) {
+								if (
+									this.reconnectAdvised &&
+									!this.reconnectDeclined &&
+									!stream.writableEnded
+								) {
 									stream.end();
 								}
 							}
@@ -948,10 +991,13 @@ class S2SAppendSession implements TransportAppendSession {
 	 * Pipelined: multiple sends can be in-flight; acks resolve FIFO.
 	 */
 	private async sendBatch(input: Types.AppendInput): Promise<AppendResult> {
-		if (this.reconnectAdvised) {
+		if (this.reconnectAdvised && !this.reconnectDeclined) {
 			// Refuse the advised stream without writing, so the retry layer can
 			// resubmit on a fresh session with no risk of duplication.
 			return Promise.resolve(err(reconnectAdvisedError()));
+		}
+		if (this.terminalError) {
+			return Promise.resolve(err(this.terminalError));
 		}
 		if (!this.http2Stream || this.http2Stream.closed) {
 			return Promise.resolve(

--- a/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/pool.ts
@@ -95,6 +95,17 @@ interface RequestStreamOptions {
 	http2?: Http2Settings;
 }
 
+export interface PooledStream {
+	stream: ClientHttp2Stream;
+	/**
+	 * Poison the pooled connection the stream is served on, so no new stream
+	 * reuses a connection pinned to a draining server. Streams already on the
+	 * connection are left to finish. Poisoning the same connection again —
+	 * including from another stream sharing it — is a no-op.
+	 */
+	poison: () => void;
+}
+
 export class Http2ConnectionPool {
 	private readonly endpoints = new Map<string, Endpoint>();
 	private readonly maxStreamsPerConnection: number;
@@ -175,7 +186,7 @@ export class Http2ConnectionPool {
 		origin: string,
 		headers: OutgoingHttpHeaders,
 		options?: RequestStreamOptions,
-	): Promise<ClientHttp2Stream> {
+	): Promise<PooledStream> {
 		const key = endpointKey(origin, resolveHttp2Settings(options?.http2));
 		for (let attempt = 0; attempt < 3; attempt++) {
 			const endpoint = this.endpoints.get(key);
@@ -191,7 +202,7 @@ export class Http2ConnectionPool {
 				(c) => !c.dead && c.activeStreams < this.maxStreamsPerConnection,
 			);
 			if (usable) {
-				return this.openStream(usable, headers);
+				return this.pooledStream(key, usable, headers);
 			}
 
 			// Join an in-progress connect if it still has room for this stream.
@@ -207,13 +218,25 @@ export class Http2ConnectionPool {
 				continue;
 			}
 			// The reservation was already counted into activeStreams on connect.
-			return this.openStream(connection, headers, { reserved: true });
+			return this.pooledStream(key, connection, headers, { reserved: true });
 		}
 		throw new S2Error({
 			message: `HTTP/2 connections to ${origin} closed repeatedly before use`,
 			status: 500,
 			origin: "sdk",
 		});
+	}
+
+	private pooledStream(
+		key: string,
+		connection: PooledConnection,
+		headers: OutgoingHttpHeaders,
+		opts?: { reserved: boolean },
+	): PooledStream {
+		return {
+			stream: this.openStream(connection, headers, opts),
+			poison: () => this.evict(key, connection),
+		};
 	}
 
 	/** Number of live pooled connections to an endpoint. */

--- a/packages/streamstore/src/lib/stream/types.ts
+++ b/packages/streamstore/src/lib/stream/types.ts
@@ -188,6 +188,10 @@ export interface ReadSession<Format extends "string" | "bytes" = "string">
 		AsyncDisposable {
 	/**
 	 * Get the next read position, if known.
+	 *
+	 * This is the position of the next record the session expects: one past the
+	 * last record delivered, or the reported tail once an empty batch shows the
+	 * session is caught up. A reconnect resumes from here.
 	 */
 	nextReadPosition(): Types.StreamPosition | undefined;
 	/**

--- a/packages/streamstore/src/tests/h2-pool.test.ts
+++ b/packages/streamstore/src/tests/h2-pool.test.ts
@@ -142,7 +142,7 @@ describe("Http2ConnectionPool", () => {
 			});
 
 			pool.attach(server.origin);
-			const [s1, s2] = await Promise.all([
+			const [{ stream: s1 }, { stream: s2 }] = await Promise.all([
 				pool.request(server.origin, GET_HEADERS),
 				pool.request(server.origin, GET_HEADERS),
 			]);
@@ -170,11 +170,13 @@ describe("Http2ConnectionPool", () => {
 			});
 
 			pool.attach(server.origin);
-			const streams = await Promise.all([
-				pool.request(server.origin, GET_HEADERS),
-				pool.request(server.origin, GET_HEADERS),
-				pool.request(server.origin, GET_HEADERS),
-			]);
+			const streams = (
+				await Promise.all([
+					pool.request(server.origin, GET_HEADERS),
+					pool.request(server.origin, GET_HEADERS),
+					pool.request(server.origin, GET_HEADERS),
+				])
+			).map((pooled) => pooled.stream);
 
 			expect(pool.connectionCount(server.origin)).toBe(2);
 			await waitFor(() => server.sessionCount() === 2);
@@ -187,7 +189,7 @@ describe("Http2ConnectionPool", () => {
 			}
 			server.endAllStreams();
 			await waitFor(() => streams.every((s) => s.closed));
-			const reused = await pool.request(server.origin, GET_HEADERS);
+			const { stream: reused } = await pool.request(server.origin, GET_HEADERS);
 			await sleep(50);
 			expect(server.sessionCount()).toBe(2);
 
@@ -206,7 +208,7 @@ describe("Http2ConnectionPool", () => {
 
 			pool.attach(server.origin);
 			pool.attach(server.origin);
-			const stream = await pool.request(server.origin, GET_HEADERS);
+			const { stream } = await pool.request(server.origin, GET_HEADERS);
 			stream.close();
 			server.endAllStreams();
 
@@ -228,7 +230,7 @@ describe("Http2ConnectionPool", () => {
 			const pool = new Http2ConnectionPool();
 
 			pool.attach(server.origin);
-			const first = await pool.request(server.origin, GET_HEADERS);
+			const { stream: first } = await pool.request(server.origin, GET_HEADERS);
 			first.on("error", () => {});
 			await waitFor(() => server.sessionCount() === 1);
 
@@ -237,7 +239,7 @@ describe("Http2ConnectionPool", () => {
 			}
 			await waitFor(() => pool.connectionCount(server.origin) === 0);
 
-			const second = await pool.request(server.origin, GET_HEADERS);
+			const { stream: second } = await pool.request(server.origin, GET_HEADERS);
 			await waitFor(() => server.sessionCount() === 2);
 
 			first.close();
@@ -259,7 +261,9 @@ describe("Http2ConnectionPool", () => {
 			};
 
 			pool.attach(server.origin, http2);
-			const stream = await pool.request(server.origin, GET_HEADERS, { http2 });
+			const { stream } = await pool.request(server.origin, GET_HEADERS, {
+				http2,
+			});
 			await waitFor(() => server.sessionCount() === 1);
 			const [session] = [...server.openSessions()];
 			if (!session) throw new Error("no server session");
@@ -292,8 +296,12 @@ describe("Http2ConnectionPool", () => {
 
 			pool.attach(server.origin, a);
 			pool.attach(server.origin, b);
-			const s1 = await pool.request(server.origin, GET_HEADERS, { http2: a });
-			const s2 = await pool.request(server.origin, GET_HEADERS, { http2: b });
+			const { stream: s1 } = await pool.request(server.origin, GET_HEADERS, {
+				http2: a,
+			});
+			const { stream: s2 } = await pool.request(server.origin, GET_HEADERS, {
+				http2: b,
+			});
 
 			expect(pool.connectionCount(server.origin, a)).toBe(1);
 			expect(pool.connectionCount(server.origin, b)).toBe(1);
@@ -323,10 +331,10 @@ describe("Http2ConnectionPool", () => {
 
 			pool.attach(server.origin, settings());
 			pool.attach(server.origin, settings());
-			const s1 = await pool.request(server.origin, GET_HEADERS, {
+			const { stream: s1 } = await pool.request(server.origin, GET_HEADERS, {
 				http2: settings(),
 			});
-			const s2 = await pool.request(server.origin, GET_HEADERS, {
+			const { stream: s2 } = await pool.request(server.origin, GET_HEADERS, {
 				http2: settings(),
 			});
 
@@ -370,7 +378,7 @@ describe("Http2ConnectionPool", () => {
 			const pool = new Http2ConnectionPool();
 
 			pool.attach(server.origin);
-			const first = await pool.request(server.origin, GET_HEADERS);
+			const { stream: first } = await pool.request(server.origin, GET_HEADERS);
 			first.on("error", () => {});
 			await waitFor(() => server.sessionCount() === 1);
 
@@ -379,7 +387,7 @@ describe("Http2ConnectionPool", () => {
 			}
 			await waitFor(() => pool.connectionCount(server.origin) === 0);
 
-			const second = await pool.request(server.origin, GET_HEADERS);
+			const { stream: second } = await pool.request(server.origin, GET_HEADERS);
 			await waitFor(() => server.sessionCount() === 2);
 
 			second.close();

--- a/packages/streamstore/src/tests/reconnectAdvice.test.ts
+++ b/packages/streamstore/src/tests/reconnectAdvice.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { RECONNECT_ADVISED_CODE, reconnectAdvisedError } from "../error.js";
+import {
+	isServerDraining,
+	RECONNECT_ADVISED_CODE,
+	reconnectAdvisedError,
+	S2Error,
+} from "../error.js";
 import { AdvisedReconnects } from "../lib/reconnect.js";
 import { isRetryable } from "../lib/retry.js";
 import { S2SFrameParser } from "../lib/stream/transport/s2s/framing.js";
@@ -58,6 +63,18 @@ describe("reconnect advice error", () => {
 		const error = reconnectAdvisedError();
 		expect(error.code).toBe(RECONNECT_ADVISED_CODE);
 		expect(error.status).toBe(503);
+		expect(isRetryable(error)).toBe(true);
+		expect(error.hasNoSideEffects()).toBe(true);
+	});
+
+	it("classifies terminal server_draining as retryable and free of side effects", () => {
+		const error = new S2Error({
+			message: "server draining",
+			status: 503,
+			code: "server_draining",
+			origin: "server",
+		});
+		expect(isServerDraining(error)).toBe(true);
 		expect(isRetryable(error)).toBe(true);
 		expect(error.hasNoSideEffects()).toBe(true);
 	});

--- a/packages/streamstore/src/tests/reconnectAdvice.test.ts
+++ b/packages/streamstore/src/tests/reconnectAdvice.test.ts
@@ -63,21 +63,18 @@ describe("reconnect advice error", () => {
 	});
 });
 
-describe("advised reconnect pacing", () => {
-	it("allows three immediate reconnects before delaying", () => {
+describe("advised reconnects", () => {
+	it("acts on one advice before staying on", () => {
 		const advised = new AdvisedReconnects();
-		expect(advised.record(0)).toBe(0);
-		expect(advised.record(1)).toBe(0);
-		expect(advised.record(2)).toBe(0);
-		expect(advised.record(3)).toBeGreaterThan(0);
+		expect(advised.shouldReconnect(0)).toBe(true);
+		advised.record(0);
+		expect(advised.shouldReconnect(1)).toBe(false);
 	});
 
-	it("resets the count once advice stops arriving", () => {
+	it("allows another reconnect after the idle gap", () => {
 		const advised = new AdvisedReconnects();
 		advised.record(0);
-		advised.record(1);
-		advised.record(2);
-		advised.record(3);
-		expect(advised.record(30_000)).toBe(0);
+		expect(advised.shouldReconnect(60_000)).toBe(false);
+		expect(advised.shouldReconnect(60_001)).toBe(true);
 	});
 });

--- a/packages/streamstore/src/tests/reconnectAdvice.test.ts
+++ b/packages/streamstore/src/tests/reconnectAdvice.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { RECONNECT_ADVISED_CODE, reconnectAdvisedError } from "../error.js";
+import { AdvisedReconnects } from "../lib/reconnect.js";
+import { isRetryable } from "../lib/retry.js";
+import { S2SFrameParser } from "../lib/stream/transport/s2s/framing.js";
+
+function rawFrame(flag: number, body = new Uint8Array(0)) {
+	const length = 1 + body.length;
+	return new Uint8Array([
+		(length >> 16) & 0xff,
+		(length >> 8) & 0xff,
+		length & 0xff,
+		flag,
+		...body,
+	]);
+}
+
+describe("reconnect advice frame flag", () => {
+	it("parses the advice bit on regular frames", () => {
+		const parser = new S2SFrameParser();
+		parser.push(rawFrame(0x10, new Uint8Array([1, 2, 3])));
+		const frame = parser.parseFrame();
+		expect(frame).toMatchObject({
+			terminal: false,
+			compression: "none",
+			reconnectAdvised: true,
+		});
+	});
+
+	it("leaves the advice bit clear when unset", () => {
+		const parser = new S2SFrameParser();
+		parser.push(rawFrame(0x00, new Uint8Array([1])));
+		expect(parser.parseFrame()?.reconnectAdvised).toBe(false);
+	});
+
+	it("reads the advice bit alongside compression", () => {
+		const parser = new S2SFrameParser();
+		parser.push(rawFrame(0x50, new Uint8Array([1])));
+		expect(parser.parseFrame()).toMatchObject({
+			compression: "gzip",
+			reconnectAdvised: true,
+		});
+	});
+
+	it("ignores the advice bit on terminal frames", () => {
+		const parser = new S2SFrameParser();
+		parser.push(rawFrame(0x90, new Uint8Array([0x01, 0xf4])));
+		expect(parser.parseFrame()).toMatchObject({
+			terminal: true,
+			statusCode: 500,
+			reconnectAdvised: false,
+		});
+	});
+});
+
+describe("reconnect advice error", () => {
+	it("is retryable and free of side effects", () => {
+		const error = reconnectAdvisedError();
+		expect(error.code).toBe(RECONNECT_ADVISED_CODE);
+		expect(error.status).toBe(503);
+		expect(isRetryable(error)).toBe(true);
+		expect(error.hasNoSideEffects()).toBe(true);
+	});
+});
+
+describe("advised reconnect pacing", () => {
+	it("allows three immediate reconnects before delaying", () => {
+		const advised = new AdvisedReconnects();
+		expect(advised.record(0)).toBe(0);
+		expect(advised.record(1)).toBe(0);
+		expect(advised.record(2)).toBe(0);
+		expect(advised.record(3)).toBeGreaterThan(0);
+	});
+
+	it("resets the count once advice stops arriving", () => {
+		const advised = new AdvisedReconnects();
+		advised.record(0);
+		advised.record(1);
+		advised.record(2);
+		advised.record(3);
+		expect(advised.record(30_000)).toBe(0);
+	});
+});

--- a/packages/streamstore/src/tests/reconnectAdvice.test.ts
+++ b/packages/streamstore/src/tests/reconnectAdvice.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	isServerDraining,
-	RECONNECT_ADVISED_CODE,
-	reconnectAdvisedError,
-	S2Error,
-} from "../error.js";
+import { RECONNECT_ADVISED_CODE, reconnectAdvisedError } from "../error.js";
 import { AdvisedReconnects } from "../lib/reconnect.js";
 import { isRetryable } from "../lib/retry.js";
 import { S2SFrameParser } from "../lib/stream/transport/s2s/framing.js";
@@ -63,18 +58,6 @@ describe("reconnect advice error", () => {
 		const error = reconnectAdvisedError();
 		expect(error.code).toBe(RECONNECT_ADVISED_CODE);
 		expect(error.status).toBe(503);
-		expect(isRetryable(error)).toBe(true);
-		expect(error.hasNoSideEffects()).toBe(true);
-	});
-
-	it("classifies terminal server_draining as retryable and free of side effects", () => {
-		const error = new S2Error({
-			message: "server draining",
-			status: 503,
-			code: "server_draining",
-			origin: "server",
-		});
-		expect(isServerDraining(error)).toBe(true);
 		expect(isRetryable(error)).toBe(true);
 		expect(error.hasNoSideEffects()).toBe(true);
 	});

--- a/packages/streamstore/src/tests/retryAppendSession.test.ts
+++ b/packages/streamstore/src/tests/retryAppendSession.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { S2Error } from "../error.js";
+import { reconnectAdvisedError, S2Error } from "../error.js";
 import { AppendInput, AppendRecord } from "../index.js";
 import type { AppendResult, CloseResult } from "../lib/result.js";
 import { err, errClose, ok, okClose } from "../lib/result.js";
@@ -423,6 +423,59 @@ describe("AppendSessionImpl (unit)", () => {
 		await expect(ticket.ack()).rejects.toMatchObject({ status: 502 });
 		expect(session.failureCause()).toMatchObject({ status: 502 });
 	});
+
+	it.each([
+		[
+			"terminal server_draining",
+			() =>
+				new S2Error({
+					message: "server draining",
+					status: 503,
+					code: "server_draining",
+					origin: "server",
+				}),
+		],
+		["reconnect advice", reconnectAdvisedError],
+	])(
+		"reconnects on %s without spending the retry budget under noSideEffects",
+		async (_label, makeError) => {
+			const sessions: FakeTransportAppendSession[] = [];
+			const session = await AppendSessionImpl.create(
+				async () => {
+					const s =
+						sessions.length < 2
+							? new FakeTransportAppendSession({
+									submitError: makeError(),
+									// Data reached the wire; only the drain contract makes this safe.
+									effectSignalled: true,
+								})
+							: new FakeTransportAppendSession();
+					sessions.push(s);
+					return s;
+				},
+				undefined,
+				{
+					minBaseDelayMillis: 1,
+					maxBaseDelayMillis: 1,
+					maxAttempts: 1,
+					appendRetryPolicy: "noSideEffects",
+				},
+			);
+
+			const p = session.submit(
+				AppendInput.create([AppendRecord.string({ body: "x" })]),
+			);
+			await Promise.resolve();
+			await vi.advanceTimersByTimeAsync(10);
+			await Promise.resolve();
+			const ticket = await p;
+			const ack = await ticket.ack();
+			expect(ack.end.seqNum - ack.start.seqNum).toBe(1);
+			expect(sessions).toHaveLength(3);
+			expect(sessions[2]!.writes).toHaveLength(1);
+			expect(session.failureCause()).toBeUndefined();
+		},
+	);
 
 	it("detects non-monotonic sequence numbers and aborts with fatal error", async () => {
 		// Create acks with non-monotonic sequence numbers

--- a/packages/streamstore/src/tests/retryAppendSession.test.ts
+++ b/packages/streamstore/src/tests/retryAppendSession.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { reconnectAdvisedError, S2Error } from "../error.js";
+import { S2Error } from "../error.js";
 import { AppendInput, AppendRecord } from "../index.js";
 import type { AppendResult, CloseResult } from "../lib/result.js";
 import { err, errClose, ok, okClose } from "../lib/result.js";
@@ -424,58 +424,48 @@ describe("AppendSessionImpl (unit)", () => {
 		expect(session.failureCause()).toMatchObject({ status: 502 });
 	});
 
-	it.each([
-		[
-			"terminal server_draining",
-			() =>
-				new S2Error({
-					message: "server draining",
-					status: 503,
-					code: "server_draining",
-					origin: "server",
-				}),
-		],
-		["reconnect advice", reconnectAdvisedError],
-	])(
-		"reconnects on %s without spending the retry budget under noSideEffects",
-		async (_label, makeError) => {
-			const sessions: FakeTransportAppendSession[] = [];
-			const session = await AppendSessionImpl.create(
-				async () => {
-					const s =
-						sessions.length < 2
-							? new FakeTransportAppendSession({
-									submitError: makeError(),
-									// Data reached the wire; only the drain contract makes this safe.
-									effectSignalled: true,
-								})
-							: new FakeTransportAppendSession();
-					sessions.push(s);
-					return s;
-				},
-				undefined,
-				{
-					minBaseDelayMillis: 1,
-					maxBaseDelayMillis: 1,
-					maxAttempts: 1,
-					appendRetryPolicy: "noSideEffects",
-				},
-			);
+	it("reconnects on server_draining without spending the retry budget under noSideEffects", async () => {
+		const sessions: FakeTransportAppendSession[] = [];
+		const session = await AppendSessionImpl.create(
+			async () => {
+				const s =
+					sessions.length < 2
+						? new FakeTransportAppendSession({
+								submitError: new S2Error({
+									message: "server draining",
+									status: 503,
+									code: "server_draining",
+									origin: "server",
+								}),
+								// Data reached the wire; only the drain contract makes this safe.
+								effectSignalled: true,
+							})
+						: new FakeTransportAppendSession();
+				sessions.push(s);
+				return s;
+			},
+			undefined,
+			{
+				minBaseDelayMillis: 1,
+				maxBaseDelayMillis: 1,
+				maxAttempts: 1,
+				appendRetryPolicy: "noSideEffects",
+			},
+		);
 
-			const p = session.submit(
-				AppendInput.create([AppendRecord.string({ body: "x" })]),
-			);
-			await Promise.resolve();
-			await vi.advanceTimersByTimeAsync(10);
-			await Promise.resolve();
-			const ticket = await p;
-			const ack = await ticket.ack();
-			expect(ack.end.seqNum - ack.start.seqNum).toBe(1);
-			expect(sessions).toHaveLength(3);
-			expect(sessions[2]!.writes).toHaveLength(1);
-			expect(session.failureCause()).toBeUndefined();
-		},
-	);
+		const p = session.submit(
+			AppendInput.create([AppendRecord.string({ body: "x" })]),
+		);
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync(10);
+		await Promise.resolve();
+		const ticket = await p;
+		const ack = await ticket.ack();
+		expect(ack.end.seqNum - ack.start.seqNum).toBe(1);
+		expect(sessions).toHaveLength(3);
+		expect(sessions[2]!.writes).toHaveLength(1);
+		expect(session.failureCause()).toBeUndefined();
+	});
 
 	it("detects non-monotonic sequence numbers and aborts with fatal error", async () => {
 		// Create acks with non-monotonic sequence numbers

--- a/packages/streamstore/src/tests/retryReadSession.test.ts
+++ b/packages/streamstore/src/tests/retryReadSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { S2Error } from "../error.js";
+import { reconnectAdvisedError, S2Error } from "../error.js";
 import type { StreamPosition } from "../generated/index.js";
 import { RetryReadSession } from "../lib/retry.js";
 import type {
@@ -491,6 +491,137 @@ describe("ReadSession caught-up signal (unit)", () => {
 		transports[1]!.push("close");
 		expect((await reader.read()).done).toBe(true);
 		reader.releaseLock();
+	});
+});
+
+describe("ReadSession drain handoff (unit)", () => {
+	const record = (seq_num: number): InternalReadRecord<"string"> => ({
+		seq_num,
+		timestamp: 1000,
+		body: "x",
+	});
+	const tailAt = (seq_num: number): StreamPosition => ({
+		seq_num,
+		timestamp: 1000,
+	});
+	const serverDraining = () =>
+		new S2Error({
+			message: "server draining",
+			status: 503,
+			code: "server_draining",
+			origin: "server",
+		});
+
+	it("anchors a tail-relative start to the tail of an empty batch before reconnecting", async () => {
+		const transports: ManualReadSession[] = [];
+		const capturedArgs: Array<ReadArgs<"string">> = [];
+		const session = await RetryReadSession.create(
+			async (args) => {
+				capturedArgs.push({ ...args });
+				const t = new ManualReadSession();
+				transports.push(t);
+				return t;
+			},
+			{ tail_offset: 0 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
+		);
+
+		const reader = session.getReader();
+		const read = reader.read();
+
+		// Heartbeat: caught up at 42 with nothing delivered yet.
+		transports[0]!.push(readBatch([], tailAt(42)));
+		await vi.waitFor(() => {
+			expect(session.nextReadPosition()).toMatchObject({ seqNum: 42 });
+		});
+		transports[0]!.push(readError(reconnectAdvisedError()));
+
+		await vi.waitFor(() => {
+			expect(transports.length).toBe(2);
+		});
+		expect(capturedArgs[0]).toMatchObject({ tail_offset: 0 });
+		expect(capturedArgs[1]?.seq_num).toBe(42);
+		expect(capturedArgs[1]?.tail_offset).toBeUndefined();
+
+		transports[1]!.push(readBatch([record(42)], tailAt(43)));
+		expect((await read).value?.seqNum).toBe(42);
+		expect(session.nextReadPosition()).toMatchObject({ seqNum: 43 });
+
+		transports[1]!.push("close");
+		expect((await reader.read()).done).toBe(true);
+		reader.releaseLock();
+	});
+
+	it.each([
+		["reconnect advice", reconnectAdvisedError],
+		["terminal server_draining", serverDraining],
+	])(
+		"reconnects on %s without spending the retry budget",
+		async (_label, makeError) => {
+			const transports: ManualReadSession[] = [];
+			const capturedArgs: Array<ReadArgs<"string">> = [];
+			const session = await RetryReadSession.create(
+				async (args) => {
+					capturedArgs.push({ ...args });
+					const t = new ManualReadSession();
+					transports.push(t);
+					return t;
+				},
+				{ seq_num: 0 },
+				{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
+			);
+
+			const reader = session.getReader();
+			transports[0]!.push(readBatch([record(0)], tailAt(1)));
+			expect((await reader.read()).value?.seqNum).toBe(0);
+			expect(session.isCaughtUp()).toBe(true);
+
+			const next = reader.read();
+			transports[0]!.push(readError(makeError()));
+			await vi.waitFor(() => {
+				expect(transports.length).toBe(2);
+			});
+			expect(session.isCaughtUp()).toBe(false);
+			expect(capturedArgs[1]?.seq_num).toBe(1);
+
+			// A second handoff is still budget-free.
+			transports[1]!.push(readError(makeError()));
+			await vi.waitFor(() => {
+				expect(transports.length).toBe(3);
+			});
+			expect(capturedArgs[2]?.seq_num).toBe(1);
+
+			transports[2]!.push(readBatch([record(1)], tailAt(2)));
+			expect((await next).value?.seqNum).toBe(1);
+
+			transports[2]!.push("close");
+			expect((await reader.read()).done).toBe(true);
+			reader.releaseLock();
+		},
+	);
+
+	it("ends instead of reconnecting when the read is already satisfied", async () => {
+		let calls = 0;
+		const session = await RetryReadSession.create(
+			async () => {
+				calls++;
+				return new FakeReadSession({
+					records: [record(0), record(1)],
+					errorAfterRecords: 2,
+					error: reconnectAdvisedError(),
+				});
+			},
+			{ count: 2 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
+		);
+
+		const results: SDKReadRecord<"string">[] = [];
+		for await (const r of session) {
+			results.push(r);
+		}
+
+		expect(results.map((r) => r.seqNum)).toEqual([0, 1]);
+		expect(calls).toBe(1);
 	});
 });
 

--- a/packages/streamstore/src/tests/retryReadSession.test.ts
+++ b/packages/streamstore/src/tests/retryReadSession.test.ts
@@ -504,14 +504,6 @@ describe("ReadSession drain handoff (unit)", () => {
 		seq_num,
 		timestamp: 1000,
 	});
-	const serverDraining = () =>
-		new S2Error({
-			message: "server draining",
-			status: 503,
-			code: "server_draining",
-			origin: "server",
-		});
-
 	it("anchors a tail-relative start to the tail of an empty batch before reconnecting", async () => {
 		const transports: ManualReadSession[] = [];
 		const capturedArgs: Array<ReadArgs<"string">> = [];
@@ -552,53 +544,47 @@ describe("ReadSession drain handoff (unit)", () => {
 		reader.releaseLock();
 	});
 
-	it.each([
-		["reconnect advice", reconnectAdvisedError],
-		["terminal server_draining", serverDraining],
-	])(
-		"reconnects on %s without spending the retry budget",
-		async (_label, makeError) => {
-			const transports: ManualReadSession[] = [];
-			const capturedArgs: Array<ReadArgs<"string">> = [];
-			const session = await RetryReadSession.create(
-				async (args) => {
-					capturedArgs.push({ ...args });
-					const t = new ManualReadSession();
-					transports.push(t);
-					return t;
-				},
-				{ seq_num: 0 },
-				{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
-			);
+	it("reconnects on advice without spending the retry budget", async () => {
+		const transports: ManualReadSession[] = [];
+		const capturedArgs: Array<ReadArgs<"string">> = [];
+		const session = await RetryReadSession.create(
+			async (args) => {
+				capturedArgs.push({ ...args });
+				const t = new ManualReadSession();
+				transports.push(t);
+				return t;
+			},
+			{ seq_num: 0 },
+			{ minBaseDelayMillis: 1, maxBaseDelayMillis: 1, maxAttempts: 1 },
+		);
 
-			const reader = session.getReader();
-			transports[0]!.push(readBatch([record(0)], tailAt(1)));
-			expect((await reader.read()).value?.seqNum).toBe(0);
-			expect(session.isCaughtUp()).toBe(true);
+		const reader = session.getReader();
+		transports[0]!.push(readBatch([record(0)], tailAt(1)));
+		expect((await reader.read()).value?.seqNum).toBe(0);
+		expect(session.isCaughtUp()).toBe(true);
 
-			const next = reader.read();
-			transports[0]!.push(readError(makeError()));
-			await vi.waitFor(() => {
-				expect(transports.length).toBe(2);
-			});
-			expect(session.isCaughtUp()).toBe(false);
-			expect(capturedArgs[1]?.seq_num).toBe(1);
+		const next = reader.read();
+		transports[0]!.push(readError(reconnectAdvisedError()));
+		await vi.waitFor(() => {
+			expect(transports.length).toBe(2);
+		});
+		expect(session.isCaughtUp()).toBe(false);
+		expect(capturedArgs[1]?.seq_num).toBe(1);
 
-			// A second handoff is still budget-free.
-			transports[1]!.push(readError(makeError()));
-			await vi.waitFor(() => {
-				expect(transports.length).toBe(3);
-			});
-			expect(capturedArgs[2]?.seq_num).toBe(1);
+		// A second handoff is still budget-free.
+		transports[1]!.push(readError(reconnectAdvisedError()));
+		await vi.waitFor(() => {
+			expect(transports.length).toBe(3);
+		});
+		expect(capturedArgs[2]?.seq_num).toBe(1);
 
-			transports[2]!.push(readBatch([record(1)], tailAt(2)));
-			expect((await next).value?.seqNum).toBe(1);
+		transports[2]!.push(readBatch([record(1)], tailAt(2)));
+		expect((await next).value?.seqNum).toBe(1);
 
-			transports[2]!.push("close");
-			expect((await reader.read()).done).toBe(true);
-			reader.releaseLock();
-		},
-	);
+		transports[2]!.push("close");
+		expect((await reader.read()).done).toBe(true);
+		reader.releaseLock();
+	});
 
 	it("ends instead of reconnecting when the read is already satisfied", async () => {
 		let calls = 0;


### PR DESCRIPTION
Sessions now act on the s2s reconnect-advice bit and recover from terminal `server_draining` without spending the ordinary retry budget.

## Changes

- Parse bit 4 (`0x10`) as reconnect advice on regular s2s frames.
- Poison the pooled connection as soon as advice or terminal `server_draining` is decoded, while existing streams may finish.
- Reconnect once on regular advice, then decline further advice for 60 seconds and stay on that connection until the server ends it.
- Deliver an advised read batch before reconnecting so its resume position is preserved.
- Drain acknowledged append work before reconnecting; later submissions move to a fresh connection.
- Treat terminal `server_draining` as a planned, budget-free handoff for both read and append sessions, including with `maxAttempts: 1`.
- End reads whose `count` or `bytes` limit is already satisfied instead of reconnecting.

The fetch transport is unchanged apart from sharing the terminal `server_draining` retry classification; reconnect-advice frames and pool poisoning are s2s-only.

## Verification

- `bun run test:core`: 481 passed, 277 skipped.
- `bun run check`: clean, including build and package API validation.
- Live staging rollout with one frontend, s2s read and append sessions, and `maxAttempts: 1`:
  - read observed reconnect advice and resumed from sequence 1;
  - idle append surfaced terminal `server_draining`, reconnected budget-free, and ACKed sequence 1;
  - the same read session received the post-rollout record.
