### PR TITLE
fix(streamstore): forward clamp on s2s read sessions

### DIFF
--- a/.changeset/s2s-read-clamp.md
+++ b/.changeset/s2s-read-clamp.md
@@ -1,0 +1,5 @@
+---
+"@s2-dev/streamstore": patch
+---
+
+Forward `clamp` on s2s read sessions. The HTTP/2 transport built its read query by hand and dropped the flag, so `readSession({ start: { clamp: true } })` returned 416 for a start beyond the tail under s2s while clamping under fetch.

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -71,6 +71,30 @@ const debug = createDebug("s2:s2s");
 
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
+/**
+ * Query string for a read session request. Every server-side read parameter
+ * is forwarded; `as` and `ignore_command_records` are client-side only.
+ */
+export function readQueryString(args: ReadArgs<any> | undefined): string {
+	const queryParams = new URLSearchParams();
+	if (!args) return "";
+
+	if (args.seq_num !== undefined)
+		queryParams.set("seq_num", args.seq_num.toString());
+	if (args.timestamp !== undefined)
+		queryParams.set("timestamp", args.timestamp.toString());
+	if (args.tail_offset !== undefined)
+		queryParams.set("tail_offset", args.tail_offset.toString());
+	if (args.clamp !== undefined) queryParams.set("clamp", String(args.clamp));
+	if (args.count !== undefined) queryParams.set("count", args.count.toString());
+	if (args.bytes !== undefined) queryParams.set("bytes", args.bytes.toString());
+	if (args.wait !== undefined) queryParams.set("wait", args.wait.toString());
+	if (typeof args.until === "number") {
+		queryParams.set("until", args.until.toString());
+	}
+	return queryParams.toString();
+}
+
 /** Opens an HTTP/2 stream to the transport's endpoint. */
 type OpenH2Stream = (
 	headers: OutgoingHttpHeaders,
@@ -316,27 +340,8 @@ class S2SReadSession<Format extends "string" | "bytes" = "string">
 					// Start the timeout timer - will fire in 20s if no tail received
 					resetTimeoutTimer();
 
-					// Build query string
-					const queryParams = new URLSearchParams();
-					const { as, ...readParams } = args ?? {};
-
-					if (readParams.seq_num !== undefined)
-						queryParams.set("seq_num", readParams.seq_num.toString());
-					if (readParams.timestamp !== undefined)
-						queryParams.set("timestamp", readParams.timestamp.toString());
-					if (readParams.tail_offset !== undefined)
-						queryParams.set("tail_offset", readParams.tail_offset.toString());
-					if (readParams.count !== undefined)
-						queryParams.set("count", readParams.count.toString());
-					if (readParams.bytes !== undefined)
-						queryParams.set("bytes", readParams.bytes.toString());
-					if (readParams.wait !== undefined)
-						queryParams.set("wait", readParams.wait.toString());
-					if (typeof readParams.until === "number") {
-						queryParams.set("until", readParams.until.toString());
-					}
-
-					const queryString = queryParams.toString();
+					const { as } = args ?? {};
+					const queryString = readQueryString(args);
 					const path = `${url.pathname}/streams/${encodeURIComponent(streamName)}/records${queryString ? `?${queryString}` : ""}`;
 
 					const acceptEncoding = await acceptEncodingHeader(compression);

--- a/packages/streamstore/src/lib/stream/transport/s2s/index.ts
+++ b/packages/streamstore/src/lib/stream/transport/s2s/index.ts
@@ -71,10 +71,7 @@ const debug = createDebug("s2:s2s");
 
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
-/**
- * Query string for a read session request. Every server-side read parameter
- * is forwarded; `as` and `ignore_command_records` are client-side only.
- */
+/** Query string for a read session request. */
 export function readQueryString(args: ReadArgs<any> | undefined): string {
 	const queryParams = new URLSearchParams();
 	if (!args) return "";

--- a/packages/streamstore/src/tests/s2s-transport.test.ts
+++ b/packages/streamstore/src/tests/s2s-transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AppendInput, AppendRecord } from "../index.js";
 import { buildProtoAppendInput } from "../lib/stream/transport/proto.js";
+import { readQueryString } from "../lib/stream/transport/s2s/index.js";
 
 const makeRecords = (): AppendRecord[] => [
 	AppendRecord.string({ body: "hello" }),
@@ -24,5 +25,50 @@ describe("S2S transport proto serialization", () => {
 		const proto = buildProtoAppendInput(input);
 
 		expect(proto.matchSeqNum).toBeUndefined();
+	});
+});
+
+describe("S2S read session query", () => {
+	it("forwards clamp alongside the start position", () => {
+		const params = new URLSearchParams(
+			readQueryString({ seq_num: 999_999, clamp: true }),
+		);
+		expect(params.get("seq_num")).toBe("999999");
+		expect(params.get("clamp")).toBe("true");
+	});
+
+	it("forwards an explicit clamp=false", () => {
+		expect(readQueryString({ tail_offset: 0, clamp: false })).toBe(
+			"tail_offset=0&clamp=false",
+		);
+	});
+
+	it("forwards every server-side read parameter and nothing else", () => {
+		const params = new URLSearchParams(
+			readQueryString({
+				timestamp: 1_700_000_000_000,
+				clamp: true,
+				count: 10,
+				bytes: 1024,
+				wait: 30,
+				until: 1_700_000_100_000,
+				as: "bytes",
+				ignore_command_records: true,
+			}),
+		);
+		expect([...params.keys()].sort()).toEqual([
+			"bytes",
+			"clamp",
+			"count",
+			"timestamp",
+			"until",
+			"wait",
+		]);
+	});
+
+	it("omits unset parameters", () => {
+		expect(readQueryString(undefined)).toBe("");
+		expect(readQueryString({})).toBe("");
+		expect(readQueryString({ seq_num: 0 })).toBe("seq_num=0");
 	});
 });


### PR DESCRIPTION
## Summary

- The s2s (HTTP/2) read transport built its query string from a hand-written list of keys and omitted `clamp`. `readSession({ start: { from: { seqNum }, clamp: true } })` therefore returned `416` for a start beyond the tail under s2s, while the fetch transport (which spreads the full `ReadArgs`) clamped to the tail. Rust, Go, and Python all forward it on their s2s sessions.
- Extract the query builder into `readQueryString` so it can be unit-tested without an HTTP/2 server, and forward `clamp` alongside the other start parameters.

Found while reviewing #343; unrelated to reconnect advice, so split out.

## Test plan

- [x] `s2s-transport.test.ts`: `clamp` forwarded (true and explicit false), every server-side parameter forwarded and client-only `as` / `ignore_command_records` excluded, unset parameters omitted.
- [x] `bun run check` clean.

Made with [Cursor](https://cursor.com)